### PR TITLE
fix: Add missing Tutorial 13 reference and root SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+For security documentation, please see [docs/SECURITY.md](docs/SECURITY.md).
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please:
+
+1. **Do NOT** open a public issue
+2. Email the maintainers directly with details
+3. Allow 48-72 hours for initial response
+
+We take security seriously and will address all legitimate reports promptly.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest (main branch) | ✅ |
+| Previous releases | ⚠️ Best effort |

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ az deployment sub create \
 |:--------|:------------|
 | [📖 Getting Started](PREREQUISITES.md) | Prerequisites, setup, and configuration |
 | [🏗️ Architecture](ARCHITECTURE.md) | System design and component overview |
-| [📚 Tutorials](tutorials/README.md) | 12 hands-on learning modules |
+| [📚 Tutorials](tutorials/README.md) | 14 hands-on learning modules |
 | [📅 POC Agenda](poc-agenda/README.md) | 3-day workshop materials |
 | [📊 Reference](GLOSSARY.md) | FAQ, glossary, and standards |
 | [🛠️ Infrastructure](infra/README.md) | Bicep IaC modules |
@@ -191,6 +191,7 @@ This POC addresses key gaming industry regulations:
 | 10 | [Teradata Migration](tutorials/10-teradata-migration/README.md) | ~2 hours |
 | 11 | [SAS Connectivity](tutorials/11-sas-connectivity/README.md) | ~2 hours |
 | 12 | [CI/CD & DevOps](tutorials/12-cicd-devops/README.md) | ~2 hours |
+| 13 | [Migration Planning](tutorials/13-migration-planning/README.md) | ~2 hours |
 
 ---
 


### PR DESCRIPTION
## Summary
- Added Tutorial 13 (Migration Planning) to docs/index.md tutorial table
- Updated tutorial count from 12 to 14 in docs/index.md
- Added root SECURITY.md (GitHub convention) pointing to detailed docs/SECURITY.md

## Gaps Fixed
- Tutorial 13 was missing from the MkDocs home page tutorial list
- SECURITY.md was only in docs/ folder (not discoverable at root)

🤖 Generated with [Claude Code](https://claude.ai/code)