### PR TITLE
Fix badge rendering, chat widget search, dark mode & README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 *Real-time insights • Medallion Architecture • Regulatory Compliance • Direct Lake BI*
 
+[📚 Documentation](https://fgarofalo56.github.io/Suppercharge_Microsoft_Fabric/) •
 [🚀 Quick Start](#-quick-start) •
 [🐳 Docker](#-docker-support) •
 [📖 Tutorials](#-tutorials) •

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 > 🏠 [Home](index.md) > 📚 [Docs](./) > 🏗️ Architecture
 
-<div align="center">
+<div align="center" markdown>
 
 # 🏗️ Architecture
 

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Best_Practices-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/COST_ESTIMATION.md
+++ b/docs/COST_ESTIMATION.md
@@ -2,7 +2,7 @@
 
 > 🏠 [Home](index.md) > 📚 [Docs](./) > 💰 Cost Estimation
 
-<div align="center">
+<div align="center" markdown>
 
 # 💰 Cost Estimation
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 > 🏠 [Home](index.md) > 📚 [Docs](./) > 🚀 Deployment
 
-<div align="center">
+<div align="center" markdown>
 
 # 🚀 Deployment Guide
 

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Business_Continuity-critical?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Reference-purple?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/GENERATOR_API_REFERENCE.md
+++ b/docs/GENERATOR_API_REFERENCE.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-API_Reference-informational?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Reference-purple?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)
@@ -341,7 +341,7 @@ Found a missing term or see an opportunity for improvement? Please:
 
 ---
 
-<div align="center">
+<div align="center" markdown>
 
 **[⬆ Back to Top](#-glossary)**
 

--- a/docs/MIGRATION_AND_RTI_RESEARCH.md
+++ b/docs/MIGRATION_AND_RTI_RESEARCH.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Research-purple?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Networking-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -2,7 +2,7 @@
 
 > 🏠 [Home](index.md) > 📚 [Docs](./) > 📋 Prerequisites
 
-<div align="center">
+<div align="center" markdown>
 
 # 📋 Prerequisites
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Getting_Started-brightgreen?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 > 🏠 [Home](index.md) > 📚 [Docs](./) > 🔐 Security
 
-<div align="center">
+<div align="center" markdown>
 
 # 🔐 Security
 

--- a/docs/best-practices/01_WORKSPACES_NAMING.md
+++ b/docs/best-practices/01_WORKSPACES_NAMING.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Configuration-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/02_DATA_GATEWAY.md
+++ b/docs/best-practices/02_DATA_GATEWAY.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Data_Gateway-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/03_PIPELINES_DATA_MOVEMENT.md
+++ b/docs/best-practices/03_PIPELINES_DATA_MOVEMENT.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Pipeline-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/04_METADATA_DRIVEN_PIPELINES.md
+++ b/docs/best-practices/04_METADATA_DRIVEN_PIPELINES.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Pipeline-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/05_SPARK_NOTEBOOKS.md
+++ b/docs/best-practices/05_SPARK_NOTEBOOKS.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Spark-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/06_DATAFLOWS.md
+++ b/docs/best-practices/06_DATAFLOWS.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Dataflow-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/07_LAKEHOUSE_SETUP.md
+++ b/docs/best-practices/07_LAKEHOUSE_SETUP.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Lakehouse-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/08_WAREHOUSE_SETUP.md
+++ b/docs/best-practices/08_WAREHOUSE_SETUP.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Warehouse-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/09_SOURCE_SPECIFIC_PATTERNS.md
+++ b/docs/best-practices/09_SOURCE_SPECIFIC_PATTERNS.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Data_Sources-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/10_DECISION_GUIDE.md
+++ b/docs/best-practices/10_DECISION_GUIDE.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Decision_Guide-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/11_ORACLE_GATEWAY_TROUBLESHOOTING.md
+++ b/docs/best-practices/11_ORACLE_GATEWAY_TROUBLESHOOTING.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Troubleshooting-blue?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/README.md
+++ b/docs/best-practices/README.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-21 | **Version**: 2.1
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Best_Practices-yellow)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/best-practices/alerting-data-activator.md
+++ b/docs/best-practices/alerting-data-activator.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category: Best Practices](https://img.shields.io/badge/Category-Best_Practices-blue?style=flat-square)
 ![Platform: Microsoft Fabric](https://img.shields.io/badge/Platform-Microsoft_Fabric-742774?style=flat-square)

--- a/docs/best-practices/capacity-planning-cost-optimization.md
+++ b/docs/best-practices/capacity-planning-cost-optimization.md
@@ -2,7 +2,7 @@
 
 # 💰 Capacity Planning & Cost Optimization for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Right-Size Your Fabric Capacity and Minimize Total Cost of Ownership**
 

--- a/docs/best-practices/customer-managed-keys.md
+++ b/docs/best-practices/customer-managed-keys.md
@@ -2,7 +2,7 @@
 
 # 🔐 Customer-Managed Keys (CMK) for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Bring Your Own Encryption Keys for Full Data Sovereignty**
 

--- a/docs/best-practices/data-governance-deep-dive.md
+++ b/docs/best-practices/data-governance-deep-dive.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category: Best Practices](https://img.shields.io/badge/Category-Best_Practices-blue?style=flat-square)
 ![Platform: Microsoft Fabric](https://img.shields.io/badge/Platform-Microsoft_Fabric-742774?style=flat-square)

--- a/docs/best-practices/data-modeling-star-schema.md
+++ b/docs/best-practices/data-modeling-star-schema.md
@@ -2,7 +2,7 @@
 
 # ⭐ Data Modeling & Star Schema Best Practices for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Design Performant Dimensional Models Optimized for Direct Lake and Power BI**
 

--- a/docs/best-practices/data-sharing-federation.md
+++ b/docs/best-practices/data-sharing-federation.md
@@ -2,7 +2,7 @@
 
 # 🔗 Data Sharing & Federation for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Cross-Workspace, Cross-Organization, and Cross-Cloud Data Access Patterns**
 

--- a/docs/best-practices/disaster-recovery-bcdr.md
+++ b/docs/best-practices/disaster-recovery-bcdr.md
@@ -2,7 +2,7 @@
 
 # 🛡️ Disaster Recovery & Business Continuity for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Protect Your Analytics Platform with Resilient Architecture and Tested Failover Procedures**
 

--- a/docs/best-practices/error-handling-monitoring.md
+++ b/docs/best-practices/error-handling-monitoring.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category: Best Practices](https://img.shields.io/badge/Category-Best_Practices-blue?style=flat-square)
 ![Platform: Microsoft Fabric](https://img.shields.io/badge/Platform-Microsoft_Fabric-742774?style=flat-square)

--- a/docs/best-practices/etl-elt-comparison-guide.md
+++ b/docs/best-practices/etl-elt-comparison-guide.md
@@ -2,7 +2,7 @@
 
 # 🔄 ETL/ELT Comparison Guide — Choosing the Right Data Movement Method
 
-<div align="center">
+<div align="center" markdown>
 
 **Side-by-Side Comparison of All 5 Fabric Data Ingestion Methods**
 

--- a/docs/best-practices/finops-cost-governance.md
+++ b/docs/best-practices/finops-cost-governance.md
@@ -2,7 +2,7 @@
 
 # 💸 FinOps & Cost Governance for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Implement FinOps Disciplines to Maximize Fabric ROI and Enforce Cost Accountability**
 

--- a/docs/best-practices/identity-rbac-patterns.md
+++ b/docs/best-practices/identity-rbac-patterns.md
@@ -2,7 +2,7 @@
 
 # 🔑 Identity & RBAC Patterns for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Least-Privilege Access Control from Entra ID to Row-Level Data**
 

--- a/docs/best-practices/incremental-refresh-cdc.md
+++ b/docs/best-practices/incremental-refresh-cdc.md
@@ -2,7 +2,7 @@
 
 # 🔄 Incremental Refresh & CDC Patterns for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Delta MERGE, Change Data Capture, and Semantic Model Incremental Refresh**
 

--- a/docs/best-practices/lakehouse-warehouse-sqldb-decision-guide.md
+++ b/docs/best-practices/lakehouse-warehouse-sqldb-decision-guide.md
@@ -2,7 +2,7 @@
 
 # 🏗️ Lakehouse vs Warehouse vs SQL Database — Decision Guide
 
-<div align="center">
+<div align="center" markdown>
 
 **Choose the Right Fabric Analytics Store for Every Workload**
 

--- a/docs/best-practices/medallion-architecture-deep-dive.md
+++ b/docs/best-practices/medallion-architecture-deep-dive.md
@@ -2,7 +2,7 @@
 
 # 🏗️ Medallion Architecture Deep Dive
 
-<div align="center">
+<div align="center" markdown>
 
 **Bronze → Silver → Gold Patterns for Casino Gaming & Federal Data Workloads**
 

--- a/docs/best-practices/migration-patterns.md
+++ b/docs/best-practices/migration-patterns.md
@@ -2,7 +2,7 @@
 
 # 🔄 Migration Patterns for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Structured Migration Playbook from Legacy Analytics to Microsoft Fabric**
 

--- a/docs/best-practices/monitoring-observability.md
+++ b/docs/best-practices/monitoring-observability.md
@@ -2,7 +2,7 @@
 
 # 📊 Monitoring & Observability for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Unified Telemetry, Dashboards, Alerting & Runbooks for Fabric Workloads**
 

--- a/docs/best-practices/multi-tenant-workspace-architecture.md
+++ b/docs/best-practices/multi-tenant-workspace-architecture.md
@@ -2,7 +2,7 @@
 
 # 🏢 Multi-Tenant Workspace Architecture for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Design Patterns for Isolating Workloads Across Tenants, Properties, and Agencies**
 

--- a/docs/best-practices/network-security.md
+++ b/docs/best-practices/network-security.md
@@ -2,7 +2,7 @@
 
 # 🔒 Network Security for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Defense-in-Depth Network Architecture for Enterprise Analytics**
 

--- a/docs/best-practices/outbound-access-protection.md
+++ b/docs/best-practices/outbound-access-protection.md
@@ -2,7 +2,7 @@
 
 # 🛡️ Outbound Access Protection (OAP)
 
-<div align="center">
+<div align="center" markdown>
 
 **Prevent Data Exfiltration with Fabric-Native Network Controls**
 

--- a/docs/best-practices/performance-parallelism.md
+++ b/docs/best-practices/performance-parallelism.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category: Best Practices](https://img.shields.io/badge/Category-Best_Practices-blue?style=flat-square)
 ![Platform: Microsoft Fabric](https://img.shields.io/badge/Platform-Microsoft_Fabric-742774?style=flat-square)

--- a/docs/best-practices/power-bi-best-practices.md
+++ b/docs/best-practices/power-bi-best-practices.md
@@ -2,7 +2,7 @@
 
 # 📊 Power BI Best Practices for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Optimize Semantic Models, DAX Performance, and Report Design for Fabric Workloads**
 

--- a/docs/best-practices/spark-runtime-migration.md
+++ b/docs/best-practices/spark-runtime-migration.md
@@ -2,7 +2,7 @@
 
 # Spark Runtime 2.0 Migration Guide
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Data_Engineering-green?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/best-practices/sql-audit-logs-compliance.md
+++ b/docs/best-practices/sql-audit-logs-compliance.md
@@ -2,7 +2,7 @@
 
 # 🔒 SQL Audit Logs & Compliance
 
-<div align="center">
+<div align="center" markdown>
 
 **Immutable Audit Trails for Regulated Workloads**
 

--- a/docs/best-practices/testing-strategies.md
+++ b/docs/best-practices/testing-strategies.md
@@ -2,7 +2,7 @@
 
 # 🧪 Testing Strategies for Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Comprehensive Quality Assurance Across the Analytics Lifecycle**
 

--- a/docs/compliance-templates/CTR_TEMPLATE.md
+++ b/docs/compliance-templates/CTR_TEMPLATE.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Compliance-red)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/compliance-templates/MICS_TEMPLATE.md
+++ b/docs/compliance-templates/MICS_TEMPLATE.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Compliance-red)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/compliance-templates/README.md
+++ b/docs/compliance-templates/README.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Compliance-red)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/compliance-templates/SAR_TEMPLATE.md
+++ b/docs/compliance-templates/SAR_TEMPLATE.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Compliance-red)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/compliance-templates/W2G_TEMPLATE.md
+++ b/docs/compliance-templates/W2G_TEMPLATE.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Compliance-red)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/data-dictionary/README.md
+++ b/docs/data-dictionary/README.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Reference-purple)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/diagrams/architecture-overview.md
+++ b/docs/diagrams/architecture-overview.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Architecture-blue)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/diagrams/cost-breakdown.md
+++ b/docs/diagrams/cost-breakdown.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Cost_Management-green)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/features/ai-copilot-configuration.md
+++ b/docs/features/ai-copilot-configuration.md
@@ -2,7 +2,7 @@
 
 # 🤖 AI Copilot Configuration & Setup
 
-<div align="center">
+<div align="center" markdown>
 
 **Enterprise-Grade AI Assistance Across Microsoft Fabric Workloads**
 

--- a/docs/features/api-for-graphql.md
+++ b/docs/features/api-for-graphql.md
@@ -2,7 +2,7 @@
 
 # 🔗 API for GraphQL - Unified Data Access Layer
 
-<div align="center">
+<div align="center" markdown>
 
 **Fabric-Native GraphQL API Item for Schema-Driven Data Access**
 

--- a/docs/features/automl-model-endpoints.md
+++ b/docs/features/automl-model-endpoints.md
@@ -2,7 +2,7 @@
 
 # 🤖 AutoML & ML Model Endpoints - Automated Training and Real-Time Serving
 
-<div align="center">
+<div align="center" markdown>
 
 **Automated Machine Learning and RESTful Model Serving in Microsoft Fabric**
 

--- a/docs/features/composite-models.md
+++ b/docs/features/composite-models.md
@@ -2,7 +2,7 @@
 
 # 🔀 Composite Models - Mixed Storage Mode Semantic Models
 
-<div align="center">
+<div align="center" markdown>
 
 **Combine Import, DirectQuery, and Direct Lake in a Single Semantic Model for Maximum Flexibility**
 

--- a/docs/features/copy-job-cdc.md
+++ b/docs/features/copy-job-cdc.md
@@ -2,7 +2,7 @@
 
 # 📋 Copy Job - Continuous Ingestion with Change Data Capture
 
-<div align="center">
+<div align="center" markdown>
 
 **Low-Code Incremental Data Ingestion for Microsoft Fabric**
 

--- a/docs/features/cross-database-queries.md
+++ b/docs/features/cross-database-queries.md
@@ -2,7 +2,7 @@
 
 # 🔗 Cross-Database Queries in Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Query Across Lakehouse, Warehouse, and SQL Database Using Three-Part Naming**
 

--- a/docs/features/data-activator.md
+++ b/docs/features/data-activator.md
@@ -2,7 +2,7 @@
 
 # 🔔 Data Activator — Real-Time Alerting and Actions
 
-<div align="center">
+<div align="center" markdown>
 
 **Rule-Based Triggers for Microsoft Fabric Data**
 

--- a/docs/features/data-agents.md
+++ b/docs/features/data-agents.md
@@ -2,7 +2,7 @@
 
 # 🤖 Fabric Data Agents - Conversational AI for Enterprise Data
 
-<div align="center">
+<div align="center" markdown>
 
 **Build Customizable Q&A Systems Over Your Fabric Data**
 

--- a/docs/features/data-mesh-enterprise-patterns.md
+++ b/docs/features/data-mesh-enterprise-patterns.md
@@ -2,7 +2,7 @@
 
 # 🏛️ Data Mesh & Enterprise Architecture Patterns
 
-<div align="center">
+<div align="center" markdown>
 
 **Scaling Microsoft Fabric Across Domains with Data Mesh Principles**
 

--- a/docs/features/dataflow-gen2.md
+++ b/docs/features/dataflow-gen2.md
@@ -2,7 +2,7 @@
 
 # 🔄 Dataflow Gen2 — Low-Code ETL with Power Query
 
-<div align="center">
+<div align="center" markdown>
 
 **Visual Data Transformation for Microsoft Fabric**
 

--- a/docs/features/dbt-fabric-integration.md
+++ b/docs/features/dbt-fabric-integration.md
@@ -2,7 +2,7 @@
 
 # 🔧 dbt Integration with Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Transform Data with dbt Natively in Fabric Data Factory**
 

--- a/docs/features/deployment-pipelines.md
+++ b/docs/features/deployment-pipelines.md
@@ -2,7 +2,7 @@
 
 # 🚀 Deployment Pipelines — Stage-Based Promotion in Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Built-In Dev/Test/Prod Lifecycle Management for Microsoft Fabric**
 

--- a/docs/features/digital-twin-builder.md
+++ b/docs/features/digital-twin-builder.md
@@ -2,7 +2,7 @@
 
 # 🏗️ Digital Twin Builder - Real-Time Entity Modeling
 
-<div align="center">
+<div align="center" markdown>
 
 **Data-Driven Representations of Physical Assets in Microsoft Fabric**
 

--- a/docs/features/direct-lake.md
+++ b/docs/features/direct-lake.md
@@ -2,7 +2,7 @@
 
 # ⚡ Direct Lake - Zero-Copy Power BI over OneLake
 
-<div align="center">
+<div align="center" markdown>
 
 **Sub-Second Analytics Directly from Delta Lake — No Import, No DirectQuery**
 

--- a/docs/features/eventhouse-vector-database.md
+++ b/docs/features/eventhouse-vector-database.md
@@ -2,7 +2,7 @@
 
 # 🧬 Eventhouse as a Vector Database - AI-Powered Semantic Search
 
-<div align="center">
+<div align="center" markdown>
 
 **Unlock AI/ML Scenarios with Vector Search in Real-Time Intelligence**
 

--- a/docs/features/fabric-iq.md
+++ b/docs/features/fabric-iq.md
@@ -2,7 +2,7 @@
 
 # 🧠 Fabric IQ - Natural Language Analytics
 
-<div align="center">
+<div align="center" markdown>
 
 **Unlock Data Insights with Natural Language**
 

--- a/docs/features/fabric-mcp.md
+++ b/docs/features/fabric-mcp.md
@@ -2,7 +2,7 @@
 
 # 🤖 Fabric MCP Server - AI Agent Data Access
 
-<div align="center">
+<div align="center" markdown>
 
 **Connect AI Agents to Microsoft Fabric via the Model Context Protocol**
 

--- a/docs/features/fabric-rest-apis.md
+++ b/docs/features/fabric-rest-apis.md
@@ -2,7 +2,7 @@
 
 # 🔌 Fabric REST APIs - Programmatic Platform Management
 
-<div align="center">
+<div align="center" markdown>
 
 **Automate Workspace Provisioning, Item Deployment, and Capacity Management via REST**
 

--- a/docs/features/fabric-sql-database.md
+++ b/docs/features/fabric-sql-database.md
@@ -2,7 +2,7 @@
 
 # 🗄️ Fabric SQL Database - Operational OLTP in Microsoft Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Fabric-Native Transactional Database with Automatic OneLake Replication**
 

--- a/docs/features/git-integration.md
+++ b/docs/features/git-integration.md
@@ -2,7 +2,7 @@
 
 # 🔀 Git Integration for Fabric
 
-<div align="center">
+<div align="center" markdown>
 
 **Source Control and Multi-Developer Collaboration**
 

--- a/docs/features/materialized-lake-views.md
+++ b/docs/features/materialized-lake-views.md
@@ -2,7 +2,7 @@
 
 # 🏔️ Materialized Lake Views - Pre-Computed Analytics Acceleration
 
-<div align="center">
+<div align="center" markdown>
 
 **Accelerate Analytics with Pre-Computed Delta Lake Views**
 

--- a/docs/features/mirroring.md
+++ b/docs/features/mirroring.md
@@ -2,7 +2,7 @@
 
 # 🔄 Mirroring - Near-Real-Time Database Replication
 
-<div align="center">
+<div align="center" markdown>
 
 **Replicate External Databases into OneLake Delta Tables — No ETL Pipelines Required**
 

--- a/docs/features/onelake-catalog.md
+++ b/docs/features/onelake-catalog.md
@@ -2,7 +2,7 @@
 
 # 📚 OneLake Catalog - Unified Data Discovery & Governance Hub
 
-<div align="center">
+<div align="center" markdown>
 
 **Discover, Endorse, and Govern All Fabric Items from a Single Pane**
 

--- a/docs/features/onelake-iceberg-interop.md
+++ b/docs/features/onelake-iceberg-interop.md
@@ -2,7 +2,7 @@
 
 # 🧊 OneLake Iceberg Interoperability
 
-<div align="center">
+<div align="center" markdown>
 
 **Seamless Multi-Engine Data Access with Delta-Iceberg Virtualization**
 

--- a/docs/features/onelake-security.md
+++ b/docs/features/onelake-security.md
@@ -2,7 +2,7 @@
 
 # 🔐 OneLake Security - Unified Data Protection
 
-<div align="center">
+<div align="center" markdown>
 
 **Define Once, Enforce Everywhere — Security That Lives with the Data**
 

--- a/docs/features/paginated-reports.md
+++ b/docs/features/paginated-reports.md
@@ -2,7 +2,7 @@
 
 # 🖨️ Paginated Reports - Pixel-Perfect Enterprise Reporting
 
-<div align="center">
+<div align="center" markdown>
 
 **Pixel-Perfect, Print-Ready Reports for Compliance Filings, Regulatory Submissions, and Operational Exports**
 

--- a/docs/features/real-time-hub.md
+++ b/docs/features/real-time-hub.md
@@ -2,7 +2,7 @@
 
 # 📡 Real-Time Hub — Event Discovery and Sharing
 
-<div align="center">
+<div align="center" markdown>
 
 **Centralized Event Catalog for Microsoft Fabric**
 

--- a/docs/features/real-time-intelligence.md
+++ b/docs/features/real-time-intelligence.md
@@ -2,7 +2,7 @@
 
 # ⚡ Real-Time Intelligence (RTI) Comprehensive Guide
 
-<div align="center">
+<div align="center" markdown>
 
 **Streaming Analytics at Scale with Microsoft Fabric**
 

--- a/docs/features/scorecards-metrics.md
+++ b/docs/features/scorecards-metrics.md
@@ -2,7 +2,7 @@
 
 # 🎯 Scorecards & Metrics - KPI Goal Tracking
 
-<div align="center">
+<div align="center" markdown>
 
 **Track Organizational Goals with Automated Status, Check-Ins, and Hierarchical Scorecards**
 

--- a/docs/features/semantic-link.md
+++ b/docs/features/semantic-link.md
@@ -2,7 +2,7 @@
 
 # 🔗 Semantic Link - Bridge Spark Notebooks and Power BI
 
-<div align="center">
+<div align="center" markdown>
 
 **Unlock Power BI Semantic Models from PySpark Notebooks with SemPy**
 

--- a/docs/features/spark-environments-job-definitions.md
+++ b/docs/features/spark-environments-job-definitions.md
@@ -2,7 +2,7 @@
 
 # ⚙️ Spark Environments & Job Definitions
 
-<div align="center">
+<div align="center" markdown>
 
 **Production-Grade Library Management and Batch Job Execution**
 

--- a/docs/features/translytical-task-flows.md
+++ b/docs/features/translytical-task-flows.md
@@ -2,7 +2,7 @@
 
 # 🔄 Translytical Task Flows - Visual Orchestration and Write-Back from Power BI
 
-<div align="center">
+<div align="center" markdown>
 
 **Bridge the Gap Between Analytics and Action with Task Flows**
 

--- a/docs/features/vnet-data-gateway.md
+++ b/docs/features/vnet-data-gateway.md
@@ -2,7 +2,7 @@
 
 # 🔒 VNet Data Gateway - Secure Connectivity from Your Virtual Network
 
-<div align="center">
+<div align="center" markdown>
 
 **Access On-Premises and Private Data Sources Securely Through Your Azure VNet**
 

--- a/docs/features/workspace-ip-firewall.md
+++ b/docs/features/workspace-ip-firewall.md
@@ -2,7 +2,7 @@
 
 # 🛡️ Workspace IP Firewall & Surge Protection
 
-<div align="center">
+<div align="center" markdown>
 
 **IP-Based Access Control and Throttling Protection for Fabric Workspaces**
 

--- a/docs/features/workspace-monitoring.md
+++ b/docs/features/workspace-monitoring.md
@@ -2,7 +2,7 @@
 
 # 📊 Workspace Monitoring - Observability for Fabric Workloads
 
-<div align="center">
+<div align="center" markdown>
 
 **Queryable System Tables for Spark, SQL, Pipeline, and Dataflow Activity**
 

--- a/docs/javascripts/copilot-chat.js
+++ b/docs/javascripts/copilot-chat.js
@@ -5,6 +5,10 @@
  * backend powered by Azure OpenAI. Supports streaming responses, markdown
  * rendering, dark/light mode, and a dedicated full-page chat experience.
  *
+ * NEW: Client-side documentation search via MkDocs search index. When the
+ * backend is unreachable, the widget falls back to local search and shows
+ * clickable links to docs pages and GitHub source files.
+ *
  * Configuration:
  *   Set window.COPILOT_CONFIG.apiEndpoint before this script loads, or it
  *   defaults to "/api/chat" (works when the Azure Function is proxied).
@@ -13,48 +17,46 @@
   "use strict";
 
   /* ── Configuration ─────────────────────────────────────────────── */
-  const CONFIG = Object.assign(
+  var CONFIG = Object.assign(
     {
-      apiEndpoint: "https://fabric-copilot-docs.azurewebsites.net/api/chat",          // Azure Function URL
-      maxHistory: 20,                     // conversation turns to keep
-      rateLimitMs: 1500,                  // min ms between sends
+      apiEndpoint: "https://fabric-copilot-docs.azurewebsites.net/api/chat",
+      maxHistory: 20,
+      rateLimitMs: 1500,
+      siteUrl: "https://fgarofalo56.github.io/Suppercharge_Microsoft_Fabric/",
+      repoUrl: "https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric",
+      repoBranch: "master",
+      docsDir: "docs",
       welcomeMessage:
-        "Hi! I'm the **Supercharge Fabric Copilot**. Ask me anything about the codebase, tutorials, architecture, compliance rules, or troubleshooting. I have full context of this repository.",
+        "Hi! I'm the **Supercharge Fabric Copilot**. Ask me anything about the codebase, tutorials, architecture, compliance rules, or troubleshooting.\n\nI can **search the documentation** and provide direct links to relevant pages. Try asking about *\"Data Flow\"*, *\"medallion architecture\"*, or *\"compliance thresholds\"*.",
     },
     window.COPILOT_CONFIG || {}
   );
 
   /* ── State ─────────────────────────────────────────────────────── */
-  let chatHistory = [];
-  let isOpen = false;
-  let isStreaming = false;
-  let lastSendTime = 0;
+  var chatHistory = [];
+  var isOpen = false;
+  var isStreaming = false;
+  var lastSendTime = 0;
+  var searchIndex = null;
+  var searchIndexLoading = false;
 
   /* ── Detect full-page mode ─────────────────────────────────────── */
-  const isFullPage = !!document.getElementById("copilot-fullpage");
+  var isFullPage = !!document.getElementById("copilot-fullpage");
 
   /* ── Utility: simple markdown → HTML ───────────────────────────── */
   function md(text) {
     if (!text) return "";
-    let html = text
-      // code blocks (```lang ... ```)
+    var html = text
       .replace(/```(\w*)\n([\s\S]*?)```/g, function (_, lang, code) {
         return '<pre><code class="language-' + (lang || "text") + '">' +
           escapeHtml(code.trim()) + "</code></pre>";
       })
-      // inline code
       .replace(/`([^`]+)`/g, "<code>$1</code>")
-      // bold
       .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-      // italic
       .replace(/\*(.+?)\*/g, "<em>$1</em>")
-      // links
       .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
-      // unordered lists
       .replace(/^- (.+)$/gm, "<li>$1</li>")
-      // wrap consecutive <li> in <ul>
       .replace(/((?:<li>.*<\/li>\n?)+)/g, "<ul>$1</ul>")
-      // line breaks → paragraphs
       .replace(/\n{2,}/g, "</p><p>")
       .replace(/\n/g, "<br>");
     return "<p>" + html + "</p>";
@@ -64,62 +66,202 @@
     return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
   }
 
-  /* ── Detect dark mode ──────────────────────────────────────────── */
-  function isDark() {
-    return document.body.getAttribute("data-md-color-scheme") === "slate";
+  /* ── Search Index ─────────────────────────────────────────────── */
+
+  function getBaseUrl() {
+    var base = document.querySelector('meta[name="base_url"]');
+    if (base) return base.getAttribute("content");
+    var link = document.querySelector('link[rel="canonical"]');
+    if (link) {
+      var url = new URL(link.getAttribute("href"));
+      return url.pathname.replace(/[^/]*$/, "");
+    }
+    return "/Suppercharge_Microsoft_Fabric/";
+  }
+
+  function loadSearchIndex(callback) {
+    if (searchIndex) { callback(searchIndex); return; }
+    if (searchIndexLoading) {
+      // Retry after a moment
+      setTimeout(function () { loadSearchIndex(callback); }, 200);
+      return;
+    }
+    searchIndexLoading = true;
+    var base = getBaseUrl();
+    fetch(base + "search/search_index.json")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        searchIndex = data;
+        searchIndexLoading = false;
+        callback(data);
+      })
+      .catch(function () {
+        searchIndexLoading = false;
+        callback(null);
+      });
+  }
+
+  /**
+   * Search the MkDocs index for matching documents.
+   * Returns top results with title, snippet, docs URL, and GitHub URL.
+   */
+  function searchDocs(query, maxResults) {
+    maxResults = maxResults || 8;
+    if (!searchIndex || !searchIndex.docs) return [];
+
+    var terms = query.toLowerCase().split(/\s+/).filter(function (t) { return t.length > 1; });
+    if (terms.length === 0) return [];
+
+    var scored = [];
+    searchIndex.docs.forEach(function (doc) {
+      var title = (doc.title || "").toLowerCase();
+      var text = (doc.text || "").toLowerCase();
+      var location = doc.location || "";
+      var score = 0;
+
+      terms.forEach(function (term) {
+        // Title matches score higher
+        if (title.indexOf(term) !== -1) score += 10;
+        // Exact word boundary match in title
+        if (new RegExp("\\b" + term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + "\\b").test(title)) score += 5;
+        // Text body matches
+        var bodyMatches = (text.match(new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), "gi")) || []).length;
+        score += Math.min(bodyMatches, 5);
+      });
+
+      // Skip very low scores and anchor-only entries (sections within a page)
+      if (score > 0 && location) {
+        // Extract a snippet around the first match
+        var snippet = "";
+        for (var i = 0; i < terms.length; i++) {
+          var idx = text.indexOf(terms[i]);
+          if (idx !== -1) {
+            var start = Math.max(0, idx - 60);
+            var end = Math.min(text.length, idx + 120);
+            snippet = (start > 0 ? "..." : "") + doc.text.substring(start, end).trim() + (end < text.length ? "..." : "");
+            break;
+          }
+        }
+        if (!snippet && doc.text) {
+          snippet = doc.text.substring(0, 150).trim() + (doc.text.length > 150 ? "..." : "");
+        }
+
+        scored.push({
+          title: doc.title || "Untitled",
+          location: location,
+          snippet: snippet,
+          score: score,
+        });
+      }
+    });
+
+    // Sort by score descending
+    scored.sort(function (a, b) { return b.score - a.score; });
+
+    // Deduplicate by base page (remove anchor fragments, keep highest score)
+    var seen = {};
+    var deduped = [];
+    scored.forEach(function (item) {
+      var basePage = item.location.split("#")[0];
+      if (!seen[basePage]) {
+        seen[basePage] = true;
+        deduped.push(item);
+      }
+    });
+
+    return deduped.slice(0, maxResults);
+  }
+
+  /**
+   * Build docs URL from a search index location.
+   */
+  function buildDocsUrl(location) {
+    return CONFIG.siteUrl + location;
+  }
+
+  /**
+   * Build GitHub source URL from a search index location.
+   */
+  function buildGitHubUrl(location) {
+    // location is like "PREREQUISITES/" or "features/fabric-iq/"
+    // Map to docs source path
+    var path = location.replace(/\/$/, "");
+    if (!path) path = "index";
+    // Most MkDocs pages map to docs/PAGE.md or docs/PAGE/index.md
+    // We'll link to the folder; GitHub shows the README/index
+    return CONFIG.repoUrl + "/blob/" + CONFIG.repoBranch + "/" + CONFIG.docsDir + "/" + path + ".md";
+  }
+
+  /**
+   * Format search results as a chat-friendly HTML string.
+   */
+  function formatSearchResults(results, query) {
+    if (results.length === 0) {
+      return "I couldn't find any documentation pages matching **\"" + escapeHtml(query) + "\"**. Try different keywords or browse the [documentation home](" + CONFIG.siteUrl + ").";
+    }
+
+    var msg = 'I found **' + results.length + ' page' + (results.length > 1 ? 's' : '') + '** matching **"' + escapeHtml(query) + '"**:\n\n';
+
+    results.forEach(function (r, i) {
+      var docsUrl = buildDocsUrl(r.location);
+      var ghUrl = buildGitHubUrl(r.location);
+      msg += '**' + (i + 1) + '. ' + escapeHtml(r.title) + '**\n';
+      if (r.snippet) {
+        // Truncate snippet for chat
+        var snip = r.snippet.length > 120 ? r.snippet.substring(0, 120) + "..." : r.snippet;
+        msg += escapeHtml(snip) + '\n';
+      }
+      msg += '[📄 View in Docs](' + docsUrl + ') · [💻 View on GitHub](' + ghUrl + ')\n\n';
+    });
+
+    msg += "---\n*Click any link above to jump directly to that page.*";
+    return msg;
   }
 
   /* ── Build DOM ─────────────────────────────────────────────────── */
   function buildWidget() {
-    // Container
-    const container = document.createElement("div");
+    var container = document.createElement("div");
     container.id = "copilot-container";
-    container.innerHTML = `
-      <!-- Floating button -->
-      <button id="copilot-btn" aria-label="Open AI Copilot Chat" title="Ask the Fabric Copilot">
-        <svg id="copilot-icon-chat" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
-        </svg>
-        <svg id="copilot-icon-close" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none">
-          <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
-        </svg>
-      </button>
-
-      <!-- Chat panel -->
-      <div id="copilot-panel" class="copilot-hidden">
-        <div id="copilot-header">
-          <div id="copilot-header-left">
-            <span id="copilot-logo">🤖</span>
-            <span id="copilot-title">Fabric Copilot</span>
-          </div>
-          <div id="copilot-header-right">
-            <button id="copilot-clear" title="Clear conversation" aria-label="Clear conversation">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
-            </button>
-            <button id="copilot-fullscreen" title="Open full-page chat" aria-label="Open full-page chat">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
-            </button>
-          </div>
-        </div>
-        <div id="copilot-messages"></div>
-        <form id="copilot-form">
-          <div id="copilot-input-wrap">
-            <textarea id="copilot-input" placeholder="Ask about Fabric, tutorials, code..." rows="1"></textarea>
-            <button type="submit" id="copilot-send" aria-label="Send message">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
-            </button>
-          </div>
-          <div id="copilot-footer">Powered by Azure OpenAI &middot; Context: this repository</div>
-        </form>
-      </div>
-    `;
+    container.innerHTML =
+      '<button id="copilot-btn" aria-label="Open AI Copilot Chat" title="Ask the Fabric Copilot">' +
+        '<svg id="copilot-icon-chat" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+          '<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>' +
+        '</svg>' +
+        '<svg id="copilot-icon-close" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none">' +
+          '<line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>' +
+        '</svg>' +
+      '</button>' +
+      '<div id="copilot-panel" class="copilot-hidden">' +
+        '<div id="copilot-header">' +
+          '<div id="copilot-header-left">' +
+            '<span id="copilot-logo">🤖</span>' +
+            '<span id="copilot-title">Fabric Copilot</span>' +
+          '</div>' +
+          '<div id="copilot-header-right">' +
+            '<button id="copilot-clear" title="Clear conversation" aria-label="Clear conversation">' +
+              '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>' +
+            '</button>' +
+            '<button id="copilot-fullscreen" title="Open full-page chat" aria-label="Open full-page chat">' +
+              '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>' +
+            '</button>' +
+          '</div>' +
+        '</div>' +
+        '<div id="copilot-messages"></div>' +
+        '<form id="copilot-form">' +
+          '<div id="copilot-input-wrap">' +
+            '<textarea id="copilot-input" placeholder="Ask about Fabric, tutorials, code..." rows="1"></textarea>' +
+            '<button type="submit" id="copilot-send" aria-label="Send message">' +
+              '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>' +
+            '</button>' +
+          '</div>' +
+          '<div id="copilot-footer">Powered by Azure OpenAI · <a href="' + CONFIG.siteUrl + '" target="_blank" style="color:inherit;text-decoration:underline;">Documentation</a></div>' +
+        '</form>' +
+      '</div>';
 
     if (isFullPage) {
-      // In full-page mode, embed inside the target div
-      const target = document.getElementById("copilot-fullpage");
+      var target = document.getElementById("copilot-fullpage");
       target.appendChild(container);
       container.classList.add("copilot-fullpage-mode");
-      // Auto-open immediately (no delay)
       togglePanel(true);
     } else {
       document.body.appendChild(container);
@@ -148,19 +290,9 @@
 
     // Show welcome message
     addMessage("assistant", CONFIG.welcomeMessage);
-  }
 
-  /* ── Get base URL for MkDocs ───────────────────────────────────── */
-  function getBaseUrl() {
-    var base = document.querySelector('meta[name="base_url"]');
-    if (base) return base.getAttribute("content");
-    // fallback: look at canonical or just use /
-    var link = document.querySelector('link[rel="canonical"]');
-    if (link) {
-      var url = new URL(link.getAttribute("href"));
-      return url.pathname.replace(/[^/]*$/, "");
-    }
-    return "/";
+    // Preload search index in background
+    loadSearchIndex(function () {});
   }
 
   /* ── Toggle panel ──────────────────────────────────────────────── */
@@ -173,19 +305,19 @@
     if (isOpen) {
       panel.classList.remove("copilot-hidden");
       panel.classList.add("copilot-visible");
-      iconChat.style.display = "none";
-      iconClose.style.display = "block";
+      if (iconChat) iconChat.style.display = "none";
+      if (iconClose) iconClose.style.display = "block";
       document.getElementById("copilot-input").focus();
     } else {
       panel.classList.remove("copilot-visible");
       panel.classList.add("copilot-hidden");
-      iconChat.style.display = "block";
-      iconClose.style.display = "none";
+      if (iconChat) iconChat.style.display = "block";
+      if (iconClose) iconClose.style.display = "none";
     }
   }
 
   /* ── Add message to chat ───────────────────────────────────────── */
-  function addMessage(role, content, isStreaming) {
+  function addMessage(role, content, streaming) {
     var messages = document.getElementById("copilot-messages");
     var div = document.createElement("div");
     div.className = "copilot-msg copilot-msg-" + role;
@@ -203,7 +335,7 @@
     messages.appendChild(div);
     messages.scrollTop = messages.scrollHeight;
 
-    if (isStreaming) {
+    if (streaming) {
       div.id = "copilot-streaming";
     }
 
@@ -246,55 +378,52 @@
     var message = input.value.trim();
     if (!message || isStreaming) return;
 
-    // Rate limit
     var now = Date.now();
     if (now - lastSendTime < CONFIG.rateLimitMs) return;
     lastSendTime = now;
 
-    // Add user message
     addMessage("user", message);
     chatHistory.push({ role: "user", content: message });
 
-    // Trim history
     if (chatHistory.length > CONFIG.maxHistory * 2) {
       chatHistory = chatHistory.slice(-CONFIG.maxHistory * 2);
     }
 
-    // Clear input
     input.value = "";
     input.style.height = "auto";
 
-    // Show typing indicator
     isStreaming = true;
     document.getElementById("copilot-send").disabled = true;
     input.disabled = true;
-    addMessage("assistant", "Thinking...", true);
+    addMessage("assistant", "Searching documentation...", true);
 
-    // Send to backend
     sendToBackend(message);
   }
 
-  /* ── Send message to Azure Function ────────────────────────────── */
+  /* ── Send message to Azure Function (with search fallback) ─────── */
   function sendToBackend(message) {
     var payload = {
       message: message,
-      history: chatHistory.slice(0, -1), // exclude the message we just added
+      history: chatHistory.slice(0, -1),
       pageContext: getPageContext(),
     };
+
+    // Set a short timeout for the backend check
+    var controller = new AbortController();
+    var timeoutId = setTimeout(function () { controller.abort(); }, 5000);
 
     fetch(CONFIG.apiEndpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
+      signal: controller.signal,
     })
       .then(function (response) {
-        if (!response.ok) {
-          throw new Error("HTTP " + response.status);
-        }
+        clearTimeout(timeoutId);
+        if (!response.ok) throw new Error("HTTP " + response.status);
 
         var contentType = response.headers.get("content-type") || "";
 
-        // Streaming response (SSE-style via ndjson)
         if (contentType.includes("text/event-stream") || contentType.includes("application/x-ndjson")) {
           var reader = response.body.getReader();
           var decoder = new TextDecoder();
@@ -308,10 +437,9 @@
                 return;
               }
               var chunk = decoder.decode(result.value, { stream: true });
-              // Each line is a JSON object with a "content" field
               chunk.split("\n").forEach(function (line) {
                 line = line.trim();
-                if (!line || line.startsWith(":")) return; // SSE comment/keepalive
+                if (!line || line.startsWith(":")) return;
                 if (line.startsWith("data: ")) line = line.substring(6);
                 if (line === "[DONE]") return;
                 try {
@@ -324,16 +452,13 @@
                     accumulated = "**Error:** " + data.error;
                     updateStreamingMessage(accumulated);
                   }
-                } catch (_) {
-                  // non-JSON line, skip
-                }
+                } catch (_) {}
               });
               readChunk();
             });
           }
           readChunk();
         } else {
-          // Non-streaming JSON response
           response.json().then(function (data) {
             var reply = data.reply || data.content || data.message || "Sorry, I couldn't generate a response.";
             updateStreamingMessage(reply);
@@ -342,16 +467,32 @@
           });
         }
       })
-      .catch(function (err) {
-        console.error("Copilot chat error:", err);
-        updateStreamingMessage(
-          "**Connection Error**\n\nCould not reach the Copilot backend. This typically means:\n\n" +
-          "- The Azure Function isn't deployed yet\n" +
-          "- The API endpoint URL needs to be configured\n\n" +
-          "See `azure-functions/copilot-chat/` in the repo for setup instructions."
-        );
-        finalizeStreaming();
+      .catch(function () {
+        clearTimeout(timeoutId);
+        // Backend unreachable — fall back to local documentation search
+        fallbackToLocalSearch(message);
       });
+  }
+
+  /* ── Local search fallback ────────────────────────────────────── */
+  function fallbackToLocalSearch(query) {
+    loadSearchIndex(function (index) {
+      if (!index) {
+        updateStreamingMessage(
+          "**Offline Mode**\n\nThe AI backend isn't available and I couldn't load the search index. " +
+          "You can browse the [documentation](" + CONFIG.siteUrl + ") directly or use the search bar above."
+        );
+        chatHistory.push({ role: "assistant", content: "Offline — search index unavailable." });
+        finalizeStreaming();
+        return;
+      }
+
+      var results = searchDocs(query);
+      var reply = formatSearchResults(results, query);
+      updateStreamingMessage(reply);
+      chatHistory.push({ role: "assistant", content: reply });
+      finalizeStreaming();
+    });
   }
 
   /* ── Clear chat ────────────────────────────────────────────────── */
@@ -364,7 +505,6 @@
 
   /* ── Initialize ────────────────────────────────────────────────── */
   function init() {
-    // Wait for DOM
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", buildWidget);
     } else {

--- a/docs/javascripts/dark-mode-auto.js
+++ b/docs/javascripts/dark-mode-auto.js
@@ -1,0 +1,27 @@
+/**
+ * Auto-detect browser dark mode preference and apply MkDocs Material slate theme.
+ * Only activates if the user hasn't manually toggled the theme via the palette switch.
+ */
+(function () {
+  "use strict";
+  var STORAGE_KEY = "__palette";
+
+  // If user has never manually toggled, respect OS preference
+  if (!localStorage.getItem(STORAGE_KEY)) {
+    if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      // Set slate scheme
+      document.body.setAttribute("data-md-color-scheme", "slate");
+      document.body.setAttribute("data-md-color-primary", "indigo");
+      document.body.setAttribute("data-md-color-accent", "amber");
+    }
+  }
+
+  // Listen for OS theme changes in real-time
+  if (window.matchMedia) {
+    window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function (e) {
+      if (!localStorage.getItem(STORAGE_KEY)) {
+        document.body.setAttribute("data-md-color-scheme", e.matches ? "slate" : "default");
+      }
+    });
+  }
+})();

--- a/docs/microsoft-fabric-features-april-2026.md
+++ b/docs/microsoft-fabric-features-april-2026.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Feature_Inventory-informational?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -5,7 +5,7 @@
 > **Last Updated**: 2026-04-15 | **Version**: 2.0
 > **Status**: ✅ Final | **Maintainer**: Documentation Team
 
-<div align="center">
+<div align="center" markdown>
 
 ![Category](https://img.shields.io/badge/Category-Operations-orange)
 ![Status](https://img.shields.io/badge/Status-Final-green)

--- a/docs/stylesheets/copilot-chat.css
+++ b/docs/stylesheets/copilot-chat.css
@@ -253,13 +253,13 @@
 
 /* ── Full-page mode ──────────────────────────────────────────── */
 #copilot-fullpage {
-  min-height: 500px;
+  min-height: 420px;
 }
 .copilot-fullpage-mode {
   display: flex;
   flex-direction: column;
-  min-height: 500px;
-  height: calc(100vh - 240px);
+  min-height: 420px;
+  height: calc(100vh - 200px);
 }
 .copilot-fullpage-mode #copilot-btn {
   display: none !important;
@@ -329,4 +329,59 @@
 @keyframes copilot-blink {
   0%, 100% { opacity: 1; }
   50% { opacity: 0; }
+}
+
+/* ── Search result links in chat ─────────────────────────────── */
+.copilot-bubble a[href*="github.io"],
+.copilot-bubble a[href*="github.com"] {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.82em;
+  font-weight: 500;
+  text-decoration: none !important;
+  margin-right: 4px;
+  transition: background 0.15s;
+}
+.copilot-bubble a[href*="github.io"] {
+  background: rgba(0, 120, 212, 0.12);
+  color: #0078d4;
+}
+.copilot-bubble a[href*="github.io"]:hover {
+  background: rgba(0, 120, 212, 0.25);
+}
+.copilot-bubble a[href*="github.com"] {
+  background: rgba(36, 41, 47, 0.08);
+  color: #24292f;
+}
+.copilot-bubble a[href*="github.com"]:hover {
+  background: rgba(36, 41, 47, 0.18);
+}
+
+/* Dark mode search result links */
+[data-md-color-scheme="slate"] .copilot-bubble a[href*="github.io"] {
+  background: rgba(59, 130, 246, 0.2);
+  color: #93bbfc;
+}
+[data-md-color-scheme="slate"] .copilot-bubble a[href*="github.io"]:hover {
+  background: rgba(59, 130, 246, 0.35);
+}
+[data-md-color-scheme="slate"] .copilot-bubble a[href*="github.com"] {
+  background: rgba(255, 255, 255, 0.1);
+  color: #c9d1d9;
+}
+[data-md-color-scheme="slate"] .copilot-bubble a[href*="github.com"]:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+/* Strong titles in search results */
+.copilot-bubble strong {
+  color: inherit;
+}
+
+/* Horizontal rule in chat */
+.copilot-bubble hr {
+  border: none;
+  border-top: 1px solid var(--md-default-fg-color--lightest, #e0e0e0);
+  margin: 0.5em 0;
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -149,6 +149,58 @@
   font-weight: 500;
 }
 
+/* ── Auto dark mode for browser/OS preference ──────────────── */
+/* When a user's browser requests dark mode and no manual toggle
+   has been clicked, apply the slate scheme automatically.       */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-md-color-switching]) body:not([data-md-color-scheme="default"]) {
+    /* Fallback dark vars for elements rendered before JS runs */
+    --md-default-bg-color: #1e1e1e;
+    --md-default-fg-color: #e0e0e0;
+    --md-code-bg-color: #2d2d2d;
+  }
+}
+
+/* Ensure tables remain readable in dark mode */
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) td,
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
+  border-color: rgba(255, 255, 255, 0.12);
+}
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) tr:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+/* Dark mode badge visibility */
+[data-md-color-scheme="slate"] .md-typeset img[src*="shields.io"] {
+  filter: brightness(1.1);
+}
+
+/* Dark mode card styling */
+[data-md-color-scheme="slate"] .md-typeset .card {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+[data-md-color-scheme="slate"] .md-typeset .card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+/* Dark mode admonition tweaks */
+[data-md-color-scheme="slate"] .md-typeset .admonition,
+[data-md-color-scheme="slate"] .md-typeset details {
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+/* Dark mode code in tables */
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) code {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+/* Dark mode duration badge */
+[data-md-color-scheme="slate"] .md-typeset .duration {
+  background-color: #b8860b;
+  color: #fff;
+}
+
 /* Responsive adjustments */
 @media screen and (max-width: 76.1875em) {
   .md-typeset .hero h1 {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ extra_css:
 
 extra_javascript:
   - https://unpkg.com/mermaid@10/dist/mermaid.min.js
+  - javascripts/dark-mode-auto.js
   - javascripts/copilot-chat.js
 
 # Extra configuration


### PR DESCRIPTION
## Summary
- Fix shields.io badge rendering on 94 docs pages by adding `markdown` attribute to `<div align="center">` tags
- Enhance copilot chat widget with client-side documentation search fallback — provides direct links to docs pages and GitHub source files when backend is unavailable
- Add automatic browser dark mode detection (`prefers-color-scheme`) with improved dark theme CSS
- Add documentation site link to README.md

## Test plan
- [ ] Verify badges render as images on https://fgarofalo56.github.io/Suppercharge_Microsoft_Fabric/PREREQUISITES/
- [ ] Test chat widget search by typing "Data Flow" or "medallion architecture" — should show clickable result links
- [ ] Enable dark mode in browser settings and verify pages render correctly
- [ ] Verify README.md shows documentation link in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)