### PR TITLE
Visual Foundation — Hero SVG, docs.css, Homepage Redesign

### DIFF
--- a/docs/assets/images/architecture-hero.svg
+++ b/docs/assets/images/architecture-hero.svg
@@ -1,0 +1,146 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" width="800" height="400" role="img" aria-label="Microsoft Fabric architecture diagram showing OneLake, Medallion flow, Real-Time Intelligence, Direct Lake to Power BI, and Purview governance">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f0f6ff"/>
+      <stop offset="100%" stop-color="#e8f4f8"/>
+    </linearGradient>
+    <linearGradient id="bgGradDark" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1a2e"/>
+      <stop offset="100%" stop-color="#16213e"/>
+    </linearGradient>
+    <linearGradient id="onelakeGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0078D4"/>
+      <stop offset="100%" stop-color="#005a9e"/>
+    </linearGradient>
+    <linearGradient id="bronzeGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#CD7F32"/>
+      <stop offset="100%" stop-color="#a0622d"/>
+    </linearGradient>
+    <linearGradient id="silverGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#C0C0C0"/>
+      <stop offset="100%" stop-color="#909090"/>
+    </linearGradient>
+    <linearGradient id="goldGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFB900"/>
+      <stop offset="100%" stop-color="#d49b00"/>
+    </linearGradient>
+    <linearGradient id="rtiGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#50E6FF"/>
+      <stop offset="100%" stop-color="#30b8d6"/>
+    </linearGradient>
+    <linearGradient id="pbiGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F2C811"/>
+      <stop offset="100%" stop-color="#d4ad0e"/>
+    </linearGradient>
+    <filter id="dropShadow" x="-4%" y="-4%" width="108%" height="116%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#00000020"/>
+    </filter>
+    <marker id="arrowBlue" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#0078D4"/>
+    </marker>
+    <marker id="arrowCyan" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#50E6FF"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="400" rx="12" fill="url(#bgGrad)"/>
+
+  <!-- Purview governance overlay band -->
+  <rect x="20" y="360" width="760" height="30" rx="6" fill="#7B2D8E" opacity="0.12"/>
+  <text x="400" y="380" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="11" fill="#7B2D8E" font-weight="600">Microsoft Purview Governance &amp; Compliance</text>
+
+  <!-- Title -->
+  <text x="400" y="32" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="16" font-weight="700" fill="#1a1a2e">Microsoft Fabric Architecture</text>
+
+  <!-- OneLake center -->
+  <rect x="310" y="130" width="180" height="110" rx="16" fill="url(#onelakeGrad)" filter="url(#dropShadow)"/>
+  <text x="400" y="175" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="15" font-weight="700" fill="#ffffff">OneLake</text>
+  <text x="400" y="196" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="10" fill="#d0e8ff">Unified Data Lake</text>
+  <text x="400" y="212" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="10" fill="#d0e8ff">Delta &amp; Iceberg</text>
+  <!-- OneLake icon (lake waves) -->
+  <path d="M370,155 Q385,148 400,155 Q415,162 430,155" stroke="#ffffff" stroke-width="1.5" fill="none" opacity="0.5"/>
+  <path d="M375,150 Q390,143 405,150 Q420,157 435,150" stroke="#ffffff" stroke-width="1" fill="none" opacity="0.3"/>
+
+  <!-- ─── Medallion flow (left side) ─── -->
+  <!-- Bronze -->
+  <rect x="40" y="60" width="120" height="70" rx="10" fill="url(#bronzeGrad)" filter="url(#dropShadow)"/>
+  <text x="100" y="92" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="13" font-weight="700" fill="#ffffff">Bronze</text>
+  <text x="100" y="110" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#ffeedd">Raw Ingestion</text>
+
+  <!-- Silver -->
+  <rect x="40" y="165" width="120" height="70" rx="10" fill="url(#silverGrad)" filter="url(#dropShadow)"/>
+  <text x="100" y="197" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="13" font-weight="700" fill="#ffffff">Silver</text>
+  <text x="100" y="215" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#f5f5f5">Cleansed &amp; Validated</text>
+
+  <!-- Gold -->
+  <rect x="40" y="270" width="120" height="70" rx="10" fill="url(#goldGrad)" filter="url(#dropShadow)"/>
+  <text x="100" y="302" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="13" font-weight="700" fill="#ffffff">Gold</text>
+  <text x="100" y="320" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#fff8e0">Business KPIs</text>
+
+  <!-- Medallion flow arrows -->
+  <line x1="100" y1="130" x2="100" y2="162" stroke="#0078D4" stroke-width="2" marker-end="url(#arrowBlue)"/>
+  <line x1="100" y1="235" x2="100" y2="267" stroke="#0078D4" stroke-width="2" marker-end="url(#arrowBlue)"/>
+
+  <!-- Bronze -> OneLake -->
+  <line x1="160" y1="95" x2="307" y2="165" stroke="#0078D4" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowBlue)"/>
+  <!-- Silver -> OneLake -->
+  <line x1="160" y1="200" x2="307" y2="190" stroke="#0078D4" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowBlue)"/>
+  <!-- Gold -> OneLake -->
+  <line x1="160" y1="300" x2="307" y2="220" stroke="#0078D4" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowBlue)"/>
+
+  <!-- ─── Real-Time Intelligence (top right) ─── -->
+  <rect x="560" y="50" width="200" height="90" rx="10" fill="url(#rtiGrad)" filter="url(#dropShadow)"/>
+  <text x="660" y="80" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="13" font-weight="700" fill="#0a3d5c">Real-Time Intelligence</text>
+  <text x="660" y="98" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#0a3d5c">Eventstreams</text>
+  <text x="660" y="112" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#0a3d5c">Eventhouse &amp; KQL</text>
+  <!-- Lightning bolt icon -->
+  <path d="M564,65 L574,65 L570,78 L578,78 L566,95 L569,82 L563,82 Z" fill="#0a3d5c" opacity="0.3"/>
+
+  <!-- RTI -> OneLake -->
+  <line x1="560" y1="110" x2="493" y2="158" stroke="#50E6FF" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrowCyan)"/>
+
+  <!-- ─── Direct Lake / Power BI (bottom right) ─── -->
+  <rect x="560" y="190" width="200" height="90" rx="10" fill="url(#pbiGrad)" filter="url(#dropShadow)"/>
+  <text x="660" y="222" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="13" font-weight="700" fill="#5b4a00">Direct Lake</text>
+  <text x="660" y="240" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#5b4a00">Power BI Analytics</text>
+  <text x="660" y="254" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#5b4a00">Sub-second Queries</text>
+  <!-- Chart icon -->
+  <rect x="570" y="210" width="4" height="18" rx="1" fill="#5b4a00" opacity="0.3"/>
+  <rect x="578" y="216" width="4" height="12" rx="1" fill="#5b4a00" opacity="0.3"/>
+  <rect x="586" y="204" width="4" height="24" rx="1" fill="#5b4a00" opacity="0.3"/>
+
+  <!-- OneLake -> Direct Lake -->
+  <line x1="493" y1="210" x2="557" y2="225" stroke="#0078D4" stroke-width="2" marker-end="url(#arrowBlue)"/>
+  <text x="524" y="208" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="8" fill="#0078D4" font-weight="600">Direct Lake</text>
+
+  <!-- ─── Data sources (far left) ─── -->
+  <rect x="40" y="5" width="120" height="30" rx="6" fill="#0078D4" opacity="0.15"/>
+  <text x="100" y="25" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#0078D4" font-weight="600">Data Sources</text>
+  <!-- Arrow from sources to Bronze -->
+  <line x1="100" y1="35" x2="100" y2="57" stroke="#0078D4" stroke-width="1.5" marker-end="url(#arrowBlue)"/>
+
+  <!-- ─── Labels ─── -->
+  <!-- Medallion label -->
+  <text x="100" y="355" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="10" fill="#666" font-weight="600">Medallion Architecture</text>
+
+  <!-- RTI label -->
+  <text x="660" y="155" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#30b8d6" font-style="italic">Streaming Ingestion</text>
+
+  <!-- BI consumers (far right) -->
+  <rect x="660" y="300" width="100" height="40" rx="8" fill="#0078D4" opacity="0.12"/>
+  <text x="710" y="318" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#0078D4" font-weight="600">BI Consumers</text>
+  <text x="710" y="332" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="8" fill="#0078D4">Reports &amp; Dashboards</text>
+  <line x1="660" y1="280" x2="700" y2="298" stroke="#0078D4" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrowBlue)"/>
+
+  <!-- Fabric IQ / Copilot badge -->
+  <rect x="320" y="260" width="160" height="32" rx="8" fill="#0078D4" opacity="0.1"/>
+  <text x="400" y="280" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#0078D4" font-weight="600">Fabric IQ &amp; AI Copilot</text>
+
+  <!-- Data Agents label -->
+  <rect x="320" y="300" width="160" height="28" rx="8" fill="#50E6FF" opacity="0.12"/>
+  <text x="400" y="318" text-anchor="middle" font-family="Segoe UI, system-ui, sans-serif" font-size="9" fill="#2c9db8" font-weight="600">Data Agents &amp; MCP</text>
+
+  <!-- Purview shield icon -->
+  <path d="M395,367 L400,363 L405,367 L405,375 Q400,379 395,375 Z" fill="#7B2D8E" opacity="0.4"/>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,215 +1,169 @@
 ---
 title: Home
-description: Supercharge Microsoft Fabric - Casino & Gaming Industry POC
+description: Supercharge Microsoft Fabric — Casino & Gaming Industry POC with Federal Agency Domains
 hide:
   - navigation
   - toc
 ---
 
-# 🎰 Supercharge Microsoft Fabric
+# Supercharge Microsoft Fabric
 
-<div class="hero" markdown>
+**Transform your operations with enterprise-grade analytics powered by Microsoft Fabric**
 
-**Transform your casino operations with enterprise-grade analytics powered by Microsoft Fabric**
+*Real-time insights · Medallion Architecture · Regulatory Compliance · Direct Lake BI*
 
-*Real-time insights • Medallion Architecture • Regulatory Compliance • Direct Lake BI*
+[Quick Start](PREREQUISITES.md){ .md-button .md-button--primary }
+[Tutorials](tutorials/README.md){ .md-button }
 
-[🚀 Quick Start](PREREQUISITES.md){ .md-button .md-button--primary }
-[📖 Tutorials](tutorials/README.md){ .md-button }
+---
+
+## Architecture at a Glance
+
+<a href="ARCHITECTURE.md" class="architecture-hero">
+  <img src="assets/images/architecture-hero.svg" alt="Microsoft Fabric architecture — OneLake, Medallion flow, Real-Time Intelligence, Direct Lake to Power BI, Purview governance">
+</a>
+
+---
+
+## Three Core Paradigms
+
+This POC is built on three paradigms that define how data flows from source to insight inside Microsoft Fabric.
+
+**OneLake** is the unified storage layer. Every workspace writes Delta and Iceberg tables to a single lake — no data movement, no copy sprawl.
+
+**Medallion Architecture** (Bronze → Silver → Gold) organizes that data by quality tier. Bronze captures raw ingestion, Silver cleanses and validates, Gold produces business-ready KPIs and star schemas.
+
+**Direct Lake** connects Power BI semantic models straight to Gold-layer Delta tables in OneLake — sub-second queries without import or DirectQuery overhead.
+
+Together they give you a single pipeline from raw events to executive dashboards, with governance enforced by Microsoft Purview at every layer.
+
+---
+
+## Start Here
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } __Quick Start__
+
+    ---
+
+    Prerequisites, Azure setup, one-click Bicep deployment
+
+    [:octicons-arrow-right-24: Get started](PREREQUISITES.md)
+
+-   :material-school:{ .lg .middle } __Tutorials__
+
+    ---
+
+    37+ hands-on modules from Bronze ingestion to AI/ML
+
+    [:octicons-arrow-right-24: Browse tutorials](tutorials/README.md)
+
+-   :material-domain:{ .lg .middle } __Architecture__
+
+    ---
+
+    System design, component overview, data flow diagrams
+
+    [:octicons-arrow-right-24: View architecture](ARCHITECTURE.md)
+
+-   :material-calendar-check:{ .lg .middle } __3-Day POC Agenda__
+
+    ---
+
+    Workshop materials: Foundation → Transformation → BI & Governance
+
+    [:octicons-arrow-right-24: View agenda](poc-agenda/README.md)
 
 </div>
 
 ---
 
-## 🎯 Overview
+## Choose Your Path
 
-This repository provides a **complete, production-ready proof-of-concept** environment for Microsoft Fabric, covering the casino/gaming industry and **8 federal agency domains** (USDA, SBA, NOAA, EPA, DOI, DOT/FAA, Tribal Healthcare, DOJ).
+<div class="grid cards" markdown>
 
-<div class="grid" markdown>
+-   :material-database-cog:{ .lg .middle } __Data Engineers__
 
-<div class="card" markdown>
+    ---
 
-### 🏛️ Medallion Architecture
+    PySpark notebooks, pipelines, ETL, medallion implementation
 
-Bronze/Silver/Gold Lakehouse pattern with Delta Lake tables
+    [:octicons-arrow-right-24: Bronze layer tutorial](tutorials/01-bronze-layer/README.md)
 
-</div>
+-   :material-chart-areaspline:{ .lg .middle } __BI Developers__
 
-<div class="card" markdown>
+    ---
 
-### ⚡ Real-Time Intelligence
+    Direct Lake, Power BI semantic models, DAX measures
 
-Casino floor monitoring with Eventstreams and Eventhouse
+    [:octicons-arrow-right-24: Direct Lake tutorial](tutorials/05-direct-lake-powerbi/README.md)
 
-</div>
+-   :material-shield-lock:{ .lg .middle } __Security & Compliance__
 
-<div class="card" markdown>
+    ---
 
-### 📊 Direct Lake
+    Purview governance, MICS, CTR/SAR, regulatory reporting
 
-Sub-second Power BI analytics with semantic models
+    [:octicons-arrow-right-24: Governance tutorial](tutorials/07-governance-purview/README.md)
 
-</div>
+-   :material-lightning-bolt:{ .lg .middle } __Real-Time Analytics__
 
-<div class="card" markdown>
+    ---
 
-### 🔐 Data Governance
+    Eventstreams, Eventhouse, KQL for streaming workloads
 
-Microsoft Purview integration for compliance
-
-</div>
+    [:octicons-arrow-right-24: Real-time tutorial](tutorials/04-real-time-analytics/README.md)
 
 </div>
 
 ---
 
-## 👥 Target Audience
+## Feature Documentation
 
-| Role | Focus Areas |
-|:-----|:------------|
-| 🏗️ **Data Architects** | System design, medallion pattern, scalability |
-| 💻 **Data Engineers** | PySpark notebooks, pipelines, ETL |
-| 📊 **BI Developers** | Direct Lake, Power BI, DAX |
-| 🔐 **Security/Compliance** | Purview, MICS, regulatory reporting |
-| 💼 **Solution Architects** | End-to-end integration, infrastructure |
+<div class="grid cards" markdown>
 
----
+-   :material-brain:{ .lg .middle } __Fabric IQ__
 
-## 🚀 Quick Start
+    ---
 
-### Prerequisites
+    Natural language data exploration with Ontology & Plan layers
 
-- Azure subscription with Fabric capacity (F64 or trial)
-- Azure CLI and Bicep tools
-- Power BI Desktop
+    [:octicons-arrow-right-24: Fabric IQ](features/fabric-iq.md)
 
-### One-Click Deployment
+-   :material-lightning-bolt:{ .lg .middle } __Real-Time Intelligence__
 
-```bash
-# Clone the repository
-git clone https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric.git
-cd Suppercharge_Microsoft_Fabric
+    ---
 
-# Deploy infrastructure
-az deployment sub create \
-  --location eastus2 \
-  --template-file infra/main.bicep \
-  --parameters infra/environments/dev/dev.bicepparam
-```
+    Eventstreams, Eventhouse, KQL, Business Events, Maps
 
-[➡️ Full Deployment Guide](DEPLOYMENT.md){ .md-button }
+    [:octicons-arrow-right-24: RTI](features/real-time-intelligence.md)
 
----
+-   :material-robot:{ .lg .middle } __AI Copilot__
 
-## 📂 Documentation Structure
+    ---
 
-| Section | Description |
-|:--------|:------------|
-| [📖 Getting Started](PREREQUISITES.md) | Prerequisites, setup, and configuration |
-| [🏗️ Architecture](ARCHITECTURE.md) | System design and component overview |
-| [📚 Tutorials](tutorials/README.md) | 37 hands-on learning modules |
-| [📅 POC Agenda](poc-agenda/README.md) | 3-day workshop materials |
-| [📊 Reference](GLOSSARY.md) | FAQ, glossary, and standards |
-| [🛠️ Infrastructure](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/tree/main/infra) | Bicep IaC modules |
-| [🏢 Best Practices](BEST_PRACTICES.md) | Workspace organization, folder structures, environments |
-| [🌐 Networking](NETWORKING.md) | Private endpoints, ExpressRoute, VPN, gateways |
-| [🔄 Disaster Recovery](DISASTER_RECOVERY.md) | Multi-region architecture, RTO/RPO, failover procedures |
-| [📋 Data Dictionary](data-dictionary/README.md) | Complete schema documentation for all layers |
-| [📕 Runbooks](runbooks/README.md) | Operational procedures and incident response |
-| [📜 Compliance Templates](compliance-templates/README.md) | CTR, SAR, W-2G, MICS reporting templates |
+    Copilot Studio integration and governance configuration
+
+    [:octicons-arrow-right-24: Copilot](features/ai-copilot-configuration.md)
+
+-   :material-lan:{ .lg .middle } __Data Mesh__
+
+    ---
+
+    Enterprise data mesh patterns with Fabric domains
+
+    [:octicons-arrow-right-24: Data Mesh](features/data-mesh-enterprise-patterns.md)
+
+</div>
+
+[:octicons-arrow-right-24: View all features](features/fabric-iq.md){ .md-button }
 
 ---
 
-## 🔧 Feature Documentation (New Fabric Experience)
+## Compliance & Governance
 
-| Feature | Description | Status |
-|:--------|:------------|:-------|
-| [Fabric IQ](features/fabric-iq.md) | Natural language data exploration with Ontology & Plan layers | GA |
-| [Real-Time Intelligence](features/real-time-intelligence.md) | Eventstreams, Eventhouse, KQL, Business Events, Maps | GA |
-| [AI Copilot](features/ai-copilot-configuration.md) | Copilot Studio integration and governance | GA |
-| [Data Mesh](features/data-mesh-enterprise-patterns.md) | Enterprise data mesh patterns with Fabric domains | GA |
-| [Digital Twin Builder](features/digital-twin-builder.md) | IoT digital twin modeling and simulation | Preview |
-| [Data Agents](features/data-agents.md) | Autonomous AI agents for data workflows | Preview |
-| [OneLake Security](features/onelake-security.md) | Workspace identity, managed VNet, trusted access | GA |
-| [OneLake Iceberg Interop](features/onelake-iceberg-interop.md) | Apache Iceberg read/write for cross-platform analytics | GA |
-| [dbt Integration](features/dbt-fabric-integration.md) | dbt Core/Cloud with Fabric SQL & Spark | GA |
-| [Materialized Lake Views](features/materialized-lake-views.md) | Pre-computed views for Direct Lake performance | Preview |
-| [Eventhouse Vector Database](features/eventhouse-vector-database.md) | Vector search in KQL for AI/RAG workloads | GA |
-| [Graph in Fabric](features/graph-in-fabric.md) | Entity relationship modeling and graph analytics | GA |
-| [Maps in Fabric](features/maps-in-fabric.md) | Native geospatial visualization in RTI dashboards | GA |
-| [Database Hub](features/database-hub.md) | Unified database management across edge/cloud/Fabric | Early Access |
-| [Mirroring](features/mirroring.md) | Near-real-time DB replication (Oracle, SAP, BigQuery, MySQL) | GA |
-| [Direct Lake](features/direct-lake.md) | Power BI reads Delta directly from OneLake | GA |
-| [Fabric SQL Database](features/fabric-sql-database.md) | OLTP workload with auto-replication to OneLake | GA |
-| [API for GraphQL](features/api-for-graphql.md) | GraphQL API layer over Fabric data items | GA |
-| [Semantic Link](features/semantic-link.md) | SemPy library bridging notebooks and semantic models | GA |
-| [OneLake Catalog](features/onelake-catalog.md) | Unified data discovery and governance hub | GA |
-| [AutoML & Model Endpoints](features/automl-model-endpoints.md) | Automated ML training and REST model deployment | GA/Preview |
-| [Translytical Task Flows](features/translytical-task-flows.md) | Write-back from Power BI reports to Lakehouse | GA |
-| [Fabric MCP](features/fabric-mcp.md) | Model Context Protocol for AI agent interaction | Preview |
-| [Workspace Monitoring](features/workspace-monitoring.md) | Queryable system tables for activity tracking | GA |
-| [Copy Job CDC](features/copy-job-cdc.md) | Low-code continuous ingestion with change data capture | GA |
-| [Federated Fabric for GCC](features/federated-fabric-gcc.md) | Cross-cloud architecture for GCC customers to use Fabric in Commercial | Guide |
-
----
-
-## 🛠️ Developer Resources
-
-| Resource | Description |
-|:---------|:------------|
-| [📓 Notebooks](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/tree/main/notebooks) | Ready-to-import Fabric notebooks (Bronze, Silver, Gold, ML) |
-| [📊 Power BI Assets](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/tree/main/powerbi) | DAX measures and TMDL semantic models |
-
----
-
-## 📊 3-Day POC Agenda
-
-| Day | Focus | Topics |
-|:---:|:------|:-------|
-| 1️⃣ | **Foundation** | Medallion architecture, Bronze layer, ingestion patterns |
-| 2️⃣ | **Transformation** | Silver/Gold layers, real-time analytics, Eventstreams |
-| 3️⃣ | **BI & Governance** | Direct Lake, Power BI, Purview, database mirroring |
-
-[📅 View Full Agenda](poc-agenda/README.md){ .md-button }
-
----
-
-## 🎰 Casino/Gaming Data Domains
-
-```mermaid
-flowchart LR
-    subgraph Bronze["🥉 Bronze Layer"]
-        A[Slot Telemetry]
-        B[Table Games]
-        C[Player Activity]
-        D[Compliance Events]
-    end
-    
-    subgraph Silver["🥈 Silver Layer"]
-        E[Cleansed Slots]
-        F[Validated Tables]
-        G[Player Profiles]
-        H[Compliance Records]
-    end
-    
-    subgraph Gold["🥇 Gold Layer"]
-        I[Machine KPIs]
-        J[Game Analytics]
-        K[Player 360]
-        L[Regulatory Reports]
-    end
-    
-    A --> E --> I
-    B --> F --> J
-    C --> G --> K
-    D --> H --> L
-```
-
----
-
-## 📜 Compliance Frameworks
-
-This POC addresses key gaming industry regulations:
+This POC addresses casino/gaming regulations (NIGC MICS, Title 31/BSA, IRS Gaming) and supports **8 federal agency domains** — USDA, SBA, NOAA, EPA, DOI, DOT/FAA, Tribal Healthcare, and DOJ.
 
 | Framework | Coverage |
 |:----------|:---------|
@@ -218,92 +172,45 @@ This POC addresses key gaming industry regulations:
 | **IRS Gaming** | W-2G, 1042-S reporting |
 | **State Gaming Commissions** | Jurisdiction-specific requirements |
 
-[🛡️ Security Documentation](SECURITY.md){ .md-button }
+[:octicons-arrow-right-24: Security documentation](SECURITY.md){ .md-button }
 
 ---
 
-## 📚 Tutorials
+## Quick Links
 
-| # | Tutorial | Duration |
-|:-:|:---------|:--------:|
-| 00 | [Environment Setup](tutorials/00-environment-setup/README.md) | ~1 hour |
-| 01 | [Bronze Layer](tutorials/01-bronze-layer/README.md) | ~2 hours |
-| 02 | [Silver Layer](tutorials/02-silver-layer/README.md) | ~2 hours |
-| 03 | [Gold Layer](tutorials/03-gold-layer/README.md) | ~2 hours |
-| 04 | [Real-Time Analytics](tutorials/04-real-time-analytics/README.md) | ~2 hours |
-| 05 | [Direct Lake & Power BI](tutorials/05-direct-lake-powerbi/README.md) | ~2 hours |
-| 06 | [Data Pipelines](tutorials/06-data-pipelines/README.md) | ~2 hours |
-| 07 | [Governance & Purview](tutorials/07-governance-purview/README.md) | ~2 hours |
-| 08 | [Database Mirroring](tutorials/08-database-mirroring/README.md) | ~2 hours |
-| 09 | [Advanced AI/ML](tutorials/09-advanced-ai-ml/README.md) | ~3 hours |
-| 10 | [Teradata Migration](tutorials/10-teradata-migration/README.md) | ~2 hours |
-| 11 | [SAS Connectivity](tutorials/11-sas-connectivity/README.md) | ~2 hours |
-| 12 | [CI/CD & DevOps](tutorials/12-cicd-devops/README.md) | ~2 hours |
-| 13 | [Migration Planning](tutorials/13-migration-planning/README.md) | ~2 hours |
-| 14 | [Security & Networking](tutorials/14-security-networking/README.md) | ~2.5 hours |
-| 15 | [Cost Optimization](tutorials/15-cost-optimization/README.md) | ~2 hours |
-| 16 | [Performance Tuning](tutorials/16-performance-tuning/README.md) | ~2.5 hours |
-| 17 | [Monitoring & Alerting](tutorials/17-monitoring-alerting/README.md) | ~2 hours |
-| 18 | [Data Sharing](tutorials/18-data-sharing/README.md) | ~1.5 hours |
-| 19 | [Copilot & AI](tutorials/19-copilot-ai/README.md) | ~1.5 hours |
-| 20 | [Workspace Best Practices](tutorials/20-workspace-best-practices/README.md) | ~2.5 hours |
-| 21 | [GeoAnalytics & ArcGIS](tutorials/21-geoanalytics-arcgis/README.md) | ~3.5 hours |
-| 22 | [Networking Connectivity](tutorials/22-networking-connectivity/README.md) | ~3.5 hours |
-| 23 | [SHIR & Data Gateways](tutorials/23-shir-data-gateways/README.md) | ~2.5 hours |
+<div class="grid cards" markdown>
 
----
+-   :fontawesome-brands-github:{ .lg .middle } __GitHub Repository__
 
-## 💰 Cost Estimation
+    ---
 
-| Component | Monthly Cost (F64) |
-|:----------|-------------------:|
-| Fabric Capacity (F64) | ~$8,500 |
-| ADLS Gen2 Storage | ~$500 |
-| Microsoft Purview | ~$800 |
-| Log Analytics | ~$300 |
-| Key Vault | ~$10 |
-| Networking | ~$200 |
-| **Total Estimate** | **~$10,310/month** |
+    Source code, issues, and releases
 
-[💰 Detailed Cost Analysis](COST_ESTIMATION.md){ .md-button }
+    [:octicons-arrow-right-24: Open on GitHub](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)
 
----
+-   :material-file-document-multiple:{ .lg .middle } __Documentation__
 
-## 🔗 Quick Links
+    ---
 
-<div class="grid" markdown>
+    Full documentation index and guides
 
-<div class="card" markdown>
+    [:octicons-arrow-right-24: Browse docs](index.md)
 
-### [:fontawesome-brands-github: GitHub Repository](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)
+-   :material-cog:{ .lg .middle } __Infrastructure__
 
-Source code and issues
+    ---
 
-</div>
+    Bicep IaC modules for Azure deployment
 
-<div class="card" markdown>
+    [:octicons-arrow-right-24: View infra](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/tree/main/infra)
 
-### [:material-file-document: Documentation](index.md)
+-   :material-currency-usd:{ .lg .middle } __Cost Estimation__
 
-Complete documentation index
+    ---
 
-</div>
+    F64 capacity breakdown — ~$10,310/month
 
-<div class="card" markdown>
-
-### [:material-school: Tutorials](tutorials/README.md)
-
-Hands-on learning path
-
-</div>
-
-<div class="card" markdown>
-
-### [:material-cog: Infrastructure](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/tree/main/infra)
-
-Bicep IaC modules
-
-</div>
+    [:octicons-arrow-right-24: Cost details](COST_ESTIMATION.md)
 
 </div>
 

--- a/docs/stylesheets/docs.css
+++ b/docs/stylesheets/docs.css
@@ -1,0 +1,71 @@
+/* docs.css — Visual foundation styles for Supercharge Microsoft Fabric */
+
+/* ── Architecture Hero ──────────────────────────────────────────── */
+.architecture-hero {
+  display: block;
+  width: 100%;
+  max-width: 1100px;
+  margin: 1.5rem auto;
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  transition: box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.architecture-hero img,
+.architecture-hero svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+a.architecture-hero {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+a.architecture-hero:hover,
+a.architecture-hero:focus-visible {
+  box-shadow: 0 8px 32px rgba(0, 120, 212, 0.18);
+  transform: translateY(-2px);
+}
+
+a.architecture-hero:focus-visible {
+  outline: 3px solid var(--md-accent-fg-color);
+  outline-offset: 2px;
+}
+
+[data-md-color-scheme="slate"] .architecture-hero {
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+[data-md-color-scheme="slate"] a.architecture-hero:hover {
+  box-shadow: 0 8px 32px rgba(80, 230, 255, 0.15);
+}
+
+/* ── Card grid gap tightening ───────────────────────────────────── */
+.md-typeset .grid.cards {
+  gap: 0.75rem;
+}
+
+/* ── Diagram container ──────────────────────────────────────────── */
+.diagram-container {
+  width: 100%;
+  max-width: 1100px;
+  margin: 1rem auto;
+  text-align: center;
+  overflow-x: auto;
+}
+
+.diagram-container .mermaid {
+  margin: 0 auto;
+}
+
+/* ── Responsive ─────────────────────────────────────────────────── */
+@media screen and (max-width: 76.1875em) {
+  .architecture-hero {
+    border-radius: 8px;
+    margin: 1rem auto;
+  }
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -81,36 +81,7 @@
   background-color: var(--md-primary-fg-color--dark);
 }
 
-/* Hero section styling (for home page) */
-.md-typeset .hero {
-  text-align: center;
-  padding: 2rem;
-  margin-bottom: 2rem;
-}
-
-.md-typeset .hero h1 {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-}
-
-/* Card grid for features */
-.md-typeset .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
-  margin: 1rem 0;
-}
-
-.md-typeset .card {
-  padding: 1.5rem;
-  border: 1px solid var(--md-default-fg-color--lightest);
-  border-radius: 8px;
-  transition: box-shadow 0.2s;
-}
-
-.md-typeset .card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
+/* Custom .hero/.grid/.card replaced by Material built-in grid cards + docs.css */
 
 /* Badge styling */
 .md-typeset .badge {
@@ -175,14 +146,7 @@
   filter: brightness(1.1);
 }
 
-/* Dark mode card styling */
-[data-md-color-scheme="slate"] .md-typeset .card {
-  border-color: rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.04);
-}
-[data-md-color-scheme="slate"] .md-typeset .card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-}
+/* Dark mode card styling now handled by Material built-in grid cards + docs.css */
 
 /* Dark mode admonition tweaks */
 [data-md-color-scheme="slate"] .md-typeset .admonition,
@@ -201,9 +165,4 @@
   color: #fff;
 }
 
-/* Responsive adjustments */
-@media screen and (max-width: 76.1875em) {
-  .md-typeset .hero h1 {
-    font-size: 1.75rem;
-  }
-}
+/* Responsive adjustments for custom components handled in docs.css */


### PR DESCRIPTION
## Summary

- Created `docs/assets/images/architecture-hero.svg` — inline SVG showing Fabric architecture with OneLake at center, Bronze/Silver/Gold medallion flow, Real-Time Intelligence, Direct Lake to Power BI, and Purview governance overlay using Fabric brand colors (#0078D4, #50E6FF, #FFB900)
- Created `docs/stylesheets/docs.css` with `.architecture-hero` class (full-width, max-width 1100px, centered, rounded corners, shadow, dark mode variant), hover affordance for linked hero images, card grid gap tightening, and `.diagram-container` class
- Rewrote `docs/index.md` to use Material grid cards with `:material-*:` icons, clickable hero SVG, three-paradigm explanation (OneLake + Medallion + Direct Lake), and "Choose your path" navigation cards — removed all custom `.hero`, `.grid`, `.card` div patterns
- Updated `docs/stylesheets/extra.css` to remove replaced `.hero`/`.grid`/`.card` CSS while preserving Fabric branding vars, admonitions, badges, and dark mode support

## Files Changed
- `docs/assets/images/architecture-hero.svg` (new)
- `docs/stylesheets/docs.css` (new)
- `docs/index.md` (rewritten)
- `docs/stylesheets/extra.css` (updated)

## Validation
- ✅ SVG exists
- ✅ docs.css exists with `.architecture-hero` class
- ✅ index.md uses Material `grid cards` pattern
- ✅ No custom `.card` divs remain in index.md

## Note
`docs/stylesheets/docs.css` needs to be added to `extra_css` in `mkdocs.yml` to take effect.

## Test plan
- [ ] Verify SVG renders correctly in browser
- [ ] Verify hero image is clickable and links to ARCHITECTURE.md
- [ ] Verify Material grid cards render in both light and dark mode
- [ ] Verify no visual regressions on homepage
- [ ] Add `docs.css` to `extra_css` in `mkdocs.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)