### PR TITLE
Navigation & mkdocs.yml Restructure

### DIFF
--- a/docs/best-practices/index.md
+++ b/docs/best-practices/index.md
@@ -1,0 +1,344 @@
+---
+title: Best Practices
+description: Enterprise best practices for Microsoft Fabric implementations
+---
+
+# Best Practices
+
+Proven patterns, architectural guidance, and operational best practices for production Microsoft Fabric deployments.
+
+## Workspace & Infrastructure
+
+<div class="grid cards" markdown>
+
+-   :material-folder-cog:{ .lg .middle } __Workspaces & Naming__
+
+    ---
+
+    Naming conventions, workspace organization, and environment structure.
+
+    [:octicons-arrow-right-24: Workspace guide](01_WORKSPACES_NAMING.md)
+
+-   :material-lan-connect:{ .lg .middle } __Data Gateway__
+
+    ---
+
+    On-premises data gateway setup, configuration, and management.
+
+    [:octicons-arrow-right-24: Gateway guide](02_DATA_GATEWAY.md)
+
+-   :material-home-analytics:{ .lg .middle } __Lakehouse Setup__
+
+    ---
+
+    Lakehouse architecture, schema design, and optimization patterns.
+
+    [:octicons-arrow-right-24: Lakehouse setup](07_LAKEHOUSE_SETUP.md)
+
+-   :material-warehouse:{ .lg .middle } __Warehouse Setup__
+
+    ---
+
+    Data Warehouse configuration, loading patterns, and query tuning.
+
+    [:octicons-arrow-right-24: Warehouse setup](08_WAREHOUSE_SETUP.md)
+
+</div>
+
+## Data Movement & Processing
+
+<div class="grid cards" markdown>
+
+-   :material-pipe:{ .lg .middle } __Pipelines & Data Movement__
+
+    ---
+
+    Pipeline design, Copy Activity optimization, and data movement patterns.
+
+    [:octicons-arrow-right-24: Pipeline guide](03_PIPELINES_DATA_MOVEMENT.md)
+
+-   :material-cog-transfer:{ .lg .middle } __Metadata-Driven Pipelines__
+
+    ---
+
+    Dynamic, configuration-driven pipelines for scalable data ingestion.
+
+    [:octicons-arrow-right-24: Metadata pipelines](04_METADATA_DRIVEN_PIPELINES.md)
+
+-   :material-notebook:{ .lg .middle } __Spark & Notebooks__
+
+    ---
+
+    PySpark optimization, notebook best practices, and Spark configuration.
+
+    [:octicons-arrow-right-24: Spark guide](05_SPARK_NOTEBOOKS.md)
+
+-   :material-pipe-wrench:{ .lg .middle } __Dataflows Gen2__
+
+    ---
+
+    Power Query dataflow patterns for low-code transformations.
+
+    [:octicons-arrow-right-24: Dataflow guide](06_DATAFLOWS.md)
+
+-   :material-refresh-auto:{ .lg .middle } __Incremental Refresh & CDC__
+
+    ---
+
+    Change data capture and incremental refresh patterns for efficiency.
+
+    [:octicons-arrow-right-24: CDC patterns](incremental-refresh-cdc.md)
+
+-   :material-compare:{ .lg .middle } __ETL/ELT Comparison__
+
+    ---
+
+    When to use ETL vs ELT approaches in Fabric workloads.
+
+    [:octicons-arrow-right-24: ETL vs ELT](etl-elt-comparison-guide.md)
+
+</div>
+
+## Source Systems & Migration
+
+<div class="grid cards" markdown>
+
+-   :material-database-cog:{ .lg .middle } __Oracle & SQL Server Patterns__
+
+    ---
+
+    Source-specific ingestion patterns for Oracle and SQL Server.
+
+    [:octicons-arrow-right-24: Source patterns](09_SOURCE_SPECIFIC_PATTERNS.md)
+
+-   :material-wrench:{ .lg .middle } __Oracle Gateway Troubleshooting__
+
+    ---
+
+    Common Oracle gateway issues, diagnostics, and resolution steps.
+
+    [:octicons-arrow-right-24: Troubleshooting](11_ORACLE_GATEWAY_TROUBLESHOOTING.md)
+
+-   :material-database-export:{ .lg .middle } __Migration Patterns__
+
+    ---
+
+    Strategies for migrating from legacy platforms to Microsoft Fabric.
+
+    [:octicons-arrow-right-24: Migration guide](migration-patterns.md)
+
+-   :material-swap-horizontal:{ .lg .middle } __Spark Runtime Migration__
+
+    ---
+
+    Upgrade path and breaking changes for Spark Runtime 2.0.
+
+    [:octicons-arrow-right-24: Runtime migration](spark-runtime-migration.md)
+
+</div>
+
+## Architecture & Design
+
+<div class="grid cards" markdown>
+
+-   :material-help-circle:{ .lg .middle } __Decision Guide__
+
+    ---
+
+    Choosing between Fabric compute engines, storage layers, and patterns.
+
+    [:octicons-arrow-right-24: Decision guide](10_DECISION_GUIDE.md)
+
+-   :material-layers-triple:{ .lg .middle } __Medallion Architecture Deep Dive__
+
+    ---
+
+    Bronze, Silver, Gold layer patterns with implementation details.
+
+    [:octicons-arrow-right-24: Medallion deep dive](medallion-architecture-deep-dive.md)
+
+-   :material-scale-balance:{ .lg .middle } __Lakehouse vs Warehouse vs SQL DB__
+
+    ---
+
+    When to choose Lakehouse, Warehouse, or SQL Database in Fabric.
+
+    [:octicons-arrow-right-24: Comparison guide](lakehouse-warehouse-sqldb-decision-guide.md)
+
+-   :material-star-four-points:{ .lg .middle } __Data Modeling & Star Schema__
+
+    ---
+
+    Dimensional modeling, star schema design, and semantic layer patterns.
+
+    [:octicons-arrow-right-24: Data modeling](data-modeling-star-schema.md)
+
+-   :material-domain:{ .lg .middle } __Multi-Tenant Architecture__
+
+    ---
+
+    Workspace isolation, tenant management, and multi-org patterns.
+
+    [:octicons-arrow-right-24: Multi-tenant guide](multi-tenant-workspace-architecture.md)
+
+</div>
+
+## Security & Governance
+
+<div class="grid cards" markdown>
+
+-   :material-shield-check:{ .lg .middle } __Data Governance Deep Dive__
+
+    ---
+
+    Purview integration, lineage, classification, and governance policies.
+
+    [:octicons-arrow-right-24: Governance guide](data-governance-deep-dive.md)
+
+-   :material-account-key:{ .lg .middle } __Identity & RBAC Patterns__
+
+    ---
+
+    Role-based access control, workspace roles, and identity management.
+
+    [:octicons-arrow-right-24: RBAC patterns](identity-rbac-patterns.md)
+
+-   :material-security-network:{ .lg .middle } __Network Security__
+
+    ---
+
+    Private endpoints, managed VNets, and network isolation patterns.
+
+    [:octicons-arrow-right-24: Network security](network-security.md)
+
+-   :material-key-variant:{ .lg .middle } __Customer-Managed Keys__
+
+    ---
+
+    CMK encryption for data-at-rest with Azure Key Vault integration.
+
+    [:octicons-arrow-right-24: CMK guide](customer-managed-keys.md)
+
+-   :material-shield-outline:{ .lg .middle } __Outbound Access Protection__
+
+    ---
+
+    Control and monitor outbound network traffic from Fabric workspaces.
+
+    [:octicons-arrow-right-24: OAP guide](outbound-access-protection.md)
+
+-   :material-clipboard-text:{ .lg .middle } __SQL Audit Logs Compliance__
+
+    ---
+
+    SQL audit logging for regulatory compliance and forensic analysis.
+
+    [:octicons-arrow-right-24: Audit logs](sql-audit-logs-compliance.md)
+
+</div>
+
+## Operations & Monitoring
+
+<div class="grid cards" markdown>
+
+-   :material-alert-circle:{ .lg .middle } __Error Handling & Monitoring__
+
+    ---
+
+    Error handling patterns, retry logic, and monitoring setup.
+
+    [:octicons-arrow-right-24: Error handling](error-handling-monitoring.md)
+
+-   :material-bell-alert:{ .lg .middle } __Alerting & Data Activator__
+
+    ---
+
+    Proactive alerting with Data Activator and Azure Monitor integration.
+
+    [:octicons-arrow-right-24: Alerting guide](alerting-data-activator.md)
+
+-   :material-speedometer:{ .lg .middle } __Performance & Parallelism__
+
+    ---
+
+    Query optimization, parallel processing, and performance tuning.
+
+    [:octicons-arrow-right-24: Performance guide](performance-parallelism.md)
+
+-   :material-chart-timeline-variant:{ .lg .middle } __Monitoring & Observability__
+
+    ---
+
+    End-to-end observability with metrics, logs, and dashboards.
+
+    [:octicons-arrow-right-24: Observability](monitoring-observability.md)
+
+-   :material-infinity:{ .lg .middle } __CI/CD with fabric-cicd__
+
+    ---
+
+    Continuous integration and deployment for Fabric items.
+
+    [:octicons-arrow-right-24: CI/CD guide](fabric-cicd-deployment.md)
+
+-   :material-test-tube:{ .lg .middle } __Testing Strategies__
+
+    ---
+
+    Unit, integration, and end-to-end testing for Fabric workloads.
+
+    [:octicons-arrow-right-24: Testing guide](testing-strategies.md)
+
+</div>
+
+## Cost & Capacity
+
+<div class="grid cards" markdown>
+
+-   :material-currency-usd:{ .lg .middle } __Capacity Planning & Cost__
+
+    ---
+
+    SKU sizing, CU consumption analysis, and capacity optimization.
+
+    [:octicons-arrow-right-24: Capacity planning](capacity-planning-cost-optimization.md)
+
+-   :material-finance:{ .lg .middle } __FinOps & Cost Governance__
+
+    ---
+
+    Financial operations framework for Fabric cost management.
+
+    [:octicons-arrow-right-24: FinOps guide](finops-cost-governance.md)
+
+-   :material-restore:{ .lg .middle } __Disaster Recovery & BCDR__
+
+    ---
+
+    Business continuity, disaster recovery, and geo-redundancy patterns.
+
+    [:octicons-arrow-right-24: BCDR guide](disaster-recovery-bcdr.md)
+
+</div>
+
+## Analytics & BI
+
+<div class="grid cards" markdown>
+
+-   :material-chart-bar:{ .lg .middle } __Power BI Best Practices__
+
+    ---
+
+    Report design, DAX optimization, and semantic model patterns.
+
+    [:octicons-arrow-right-24: Power BI guide](power-bi-best-practices.md)
+
+-   :material-share-variant:{ .lg .middle } __Data Sharing & Federation__
+
+    ---
+
+    Cross-workspace sharing, external data sharing, and federation patterns.
+
+    [:octicons-arrow-right-24: Sharing guide](data-sharing-federation.md)
+
+</div>

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -1,0 +1,330 @@
+---
+title: Features
+description: Microsoft Fabric platform features and capabilities
+---
+
+# Features
+
+Explore the full spectrum of Microsoft Fabric capabilities — from real-time intelligence and AI-powered analytics to enterprise governance and connectivity.
+
+## AI & Intelligence
+
+<div class="grid cards" markdown>
+
+-   :material-brain:{ .lg .middle } __Fabric IQ__
+
+    ---
+
+    AI-driven intelligence layer with ontology, plan, and graph capabilities for smarter data operations.
+
+    [:octicons-arrow-right-24: Explore Fabric IQ](fabric-iq.md)
+
+-   :material-robot:{ .lg .middle } __AI Copilot__
+
+    ---
+
+    Configure and use AI Copilot across Fabric workloads for natural-language data interaction.
+
+    [:octicons-arrow-right-24: Configure Copilot](ai-copilot-configuration.md)
+
+-   :material-account-cog:{ .lg .middle } __Data Agents__
+
+    ---
+
+    Autonomous AI agents that perform data tasks, answer questions, and execute workflows.
+
+    [:octicons-arrow-right-24: Learn about Agents](data-agents.md)
+
+-   :material-auto-fix:{ .lg .middle } __AutoML & Model Endpoints__
+
+    ---
+
+    Automated machine learning with managed model endpoints for real-time scoring.
+
+    [:octicons-arrow-right-24: AutoML guide](automl-model-endpoints.md)
+
+-   :material-link-variant:{ .lg .middle } __Semantic Link__
+
+    ---
+
+    Connect Power BI semantic models to notebooks for advanced analytics and ML.
+
+    [:octicons-arrow-right-24: Use Semantic Link](semantic-link.md)
+
+</div>
+
+## Real-Time & Streaming
+
+<div class="grid cards" markdown>
+
+-   :material-lightning-bolt:{ .lg .middle } __Real-Time Intelligence__
+
+    ---
+
+    End-to-end real-time analytics with Eventstreams, Eventhouse, KQL, and business events.
+
+    [:octicons-arrow-right-24: Real-Time Intelligence](real-time-intelligence.md)
+
+-   :material-broadcast:{ .lg .middle } __Real-Time Hub__
+
+    ---
+
+    Centralized hub for discovering, managing, and consuming real-time data streams.
+
+    [:octicons-arrow-right-24: Real-Time Hub](real-time-hub.md)
+
+-   :material-bell-ring:{ .lg .middle } __Data Activator__
+
+    ---
+
+    Trigger automated actions based on data conditions and patterns in real time.
+
+    [:octicons-arrow-right-24: Data Activator](data-activator.md)
+
+-   :material-sync:{ .lg .middle } __Copy Job CDC__
+
+    ---
+
+    Change data capture with Copy Job for incremental data movement and synchronization.
+
+    [:octicons-arrow-right-24: Copy Job CDC](copy-job-cdc.md)
+
+</div>
+
+## Data Architecture
+
+<div class="grid cards" markdown>
+
+-   :material-web:{ .lg .middle } __Data Mesh__
+
+    ---
+
+    Enterprise data mesh patterns with domain-oriented ownership and federated governance.
+
+    [:octicons-arrow-right-24: Data Mesh patterns](data-mesh-enterprise-patterns.md)
+
+-   :material-cube-outline:{ .lg .middle } __Digital Twin Builder__
+
+    ---
+
+    Create digital twin models of physical assets for simulation and monitoring.
+
+    [:octicons-arrow-right-24: Digital Twin Builder](digital-twin-builder.md)
+
+-   :material-content-copy:{ .lg .middle } __Mirroring__
+
+    ---
+
+    Near-real-time replication of external databases into Fabric OneLake.
+
+    [:octicons-arrow-right-24: Mirroring](mirroring.md)
+
+-   :material-database-arrow-right:{ .lg .middle } __Direct Lake__
+
+    ---
+
+    Query Delta Lake tables directly from Power BI without import or DirectQuery overhead.
+
+    [:octicons-arrow-right-24: Direct Lake](direct-lake.md)
+
+-   :material-swap-horizontal:{ .lg .middle } __Translytical Task Flows__
+
+    ---
+
+    Unified transactional and analytical workflows in a single platform.
+
+    [:octicons-arrow-right-24: Task Flows](translytical-task-flows.md)
+
+</div>
+
+## Storage & Data Management
+
+<div class="grid cards" markdown>
+
+-   :material-shield-lock:{ .lg .middle } __OneLake Security__
+
+    ---
+
+    Fine-grained security controls for OneLake data access and sharing.
+
+    [:octicons-arrow-right-24: OneLake Security](onelake-security.md)
+
+-   :material-book-search:{ .lg .middle } __OneLake Catalog__
+
+    ---
+
+    Discover, classify, and govern data assets across the entire Fabric estate.
+
+    [:octicons-arrow-right-24: OneLake Catalog](onelake-catalog.md)
+
+-   :material-snowflake:{ .lg .middle } __Iceberg Interop__
+
+    ---
+
+    Apache Iceberg interoperability for cross-platform open table format access.
+
+    [:octicons-arrow-right-24: Iceberg Interop](onelake-iceberg-interop.md)
+
+-   :material-table-eye:{ .lg .middle } __Materialized Lake Views__
+
+    ---
+
+    Precomputed views over Delta tables for faster query performance.
+
+    [:octicons-arrow-right-24: Materialized Views](materialized-lake-views.md)
+
+-   :material-vector-combine:{ .lg .middle } __Vector Database__
+
+    ---
+
+    Vector storage and search in Eventhouse for AI/ML embedding workloads.
+
+    [:octicons-arrow-right-24: Vector Database](eventhouse-vector-database.md)
+
+</div>
+
+## Development & Integration
+
+<div class="grid cards" markdown>
+
+-   :material-code-braces:{ .lg .middle } __dbt Integration__
+
+    ---
+
+    Use dbt for transformation workflows with Fabric Lakehouse and Warehouse.
+
+    [:octicons-arrow-right-24: dbt Integration](dbt-fabric-integration.md)
+
+-   :material-connection:{ .lg .middle } __Fabric MCP__
+
+    ---
+
+    Model Context Protocol integration for AI agent connectivity with Fabric.
+
+    [:octicons-arrow-right-24: Fabric MCP](fabric-mcp.md)
+
+-   :material-api:{ .lg .middle } __GraphQL API__
+
+    ---
+
+    Build GraphQL endpoints over Fabric data for flexible client consumption.
+
+    [:octicons-arrow-right-24: GraphQL API](api-for-graphql.md)
+
+-   :material-database:{ .lg .middle } __SQL Database__
+
+    ---
+
+    Fully managed SQL database in Fabric for operational and transactional workloads.
+
+    [:octicons-arrow-right-24: SQL Database](fabric-sql-database.md)
+
+-   :material-git:{ .lg .middle } __Git Integration__
+
+    ---
+
+    Source control for Fabric items with Git-based version management.
+
+    [:octicons-arrow-right-24: Git Integration](git-integration.md)
+
+-   :material-rocket-launch:{ .lg .middle } __Deployment Pipelines__
+
+    ---
+
+    Promote Fabric items across dev, test, and production environments.
+
+    [:octicons-arrow-right-24: Deployment Pipelines](deployment-pipelines.md)
+
+-   :material-fire:{ .lg .middle } __Spark Environments & Jobs__
+
+    ---
+
+    Configure Spark environments, libraries, and job definitions for notebook workloads.
+
+    [:octicons-arrow-right-24: Spark Environments](spark-environments-job-definitions.md)
+
+-   :material-pipe:{ .lg .middle } __Dataflow Gen2__
+
+    ---
+
+    Low-code/no-code data transformation with Power Query Online.
+
+    [:octicons-arrow-right-24: Dataflow Gen2](dataflow-gen2.md)
+
+</div>
+
+## Analytics & BI
+
+<div class="grid cards" markdown>
+
+-   :material-monitor-dashboard:{ .lg .middle } __Workspace Monitoring__
+
+    ---
+
+    Monitor workspace activity, capacity usage, and item performance.
+
+    [:octicons-arrow-right-24: Workspace Monitoring](workspace-monitoring.md)
+
+-   :material-file-document-multiple:{ .lg .middle } __Paginated Reports__
+
+    ---
+
+    Pixel-perfect, print-ready reports for operational and regulatory needs.
+
+    [:octicons-arrow-right-24: Paginated Reports](paginated-reports.md)
+
+-   :material-chart-box:{ .lg .middle } __Scorecards & Metrics__
+
+    ---
+
+    Track KPIs and business metrics with goal-oriented scorecards.
+
+    [:octicons-arrow-right-24: Scorecards & Metrics](scorecards-metrics.md)
+
+-   :material-layers:{ .lg .middle } __Composite Models__
+
+    ---
+
+    Combine DirectQuery and import tables in a single semantic model.
+
+    [:octicons-arrow-right-24: Composite Models](composite-models.md)
+
+-   :material-database-search:{ .lg .middle } __Cross-Database Queries__
+
+    ---
+
+    Query across Lakehouse, Warehouse, and SQL Database in a single T-SQL statement.
+
+    [:octicons-arrow-right-24: Cross-Database Queries](cross-database-queries.md)
+
+</div>
+
+## Connectivity & Security
+
+<div class="grid cards" markdown>
+
+-   :material-cloud-outline:{ .lg .middle } __REST APIs__
+
+    ---
+
+    Programmatic access to Fabric resources via REST APIs for automation.
+
+    [:octicons-arrow-right-24: REST APIs](fabric-rest-apis.md)
+
+-   :material-vpn:{ .lg .middle } __VNet Data Gateway__
+
+    ---
+
+    Securely connect to on-premises and VNet-isolated data sources.
+
+    [:octicons-arrow-right-24: VNet Data Gateway](vnet-data-gateway.md)
+
+-   :material-wall:{ .lg .middle } __Workspace IP Firewall__
+
+    ---
+
+    Restrict workspace access to approved IP ranges for network security.
+
+    [:octicons-arrow-right-24: IP Firewall](workspace-ip-firewall.md)
+
+</div>

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,36 @@
+---
+title: Getting Started
+description: Get up and running with the Microsoft Fabric POC
+---
+
+# Getting Started
+
+Everything you need to provision, configure, and deploy your Microsoft Fabric POC environment.
+
+<div class="grid cards" markdown>
+
+-   :material-clipboard-check:{ .lg .middle } __Prerequisites__
+
+    ---
+
+    Required Azure subscriptions, permissions, tooling, and access needed before deployment.
+
+    [:octicons-arrow-right-24: Check prerequisites](../PREREQUISITES.md)
+
+-   :material-rocket-launch:{ .lg .middle } __Deployment Guide__
+
+    ---
+
+    Step-by-step Bicep deployment with environment parameters, what-if analysis, and validation.
+
+    [:octicons-arrow-right-24: Deploy now](../DEPLOYMENT.md)
+
+-   :material-calculator:{ .lg .middle } __Cost Estimation__
+
+    ---
+
+    SKU sizing, CU consumption estimates, and monthly cost projections for F64 capacity.
+
+    [:octicons-arrow-right-24: Estimate costs](../COST_ESTIMATION.md)
+
+</div>

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,382 @@
+---
+title: Tutorials
+description: Step-by-step tutorials for Microsoft Fabric POC implementation
+---
+
+# Tutorials
+
+Hands-on, step-by-step guides covering every aspect of the Microsoft Fabric POC — from environment setup through advanced analytics and federal agency integrations.
+
+## Getting Started
+
+<div class="grid cards" markdown>
+
+-   :material-cog:{ .lg .middle } __00 — Environment Setup__
+
+    ---
+
+    Provision your Fabric workspace, configure capacity, and prepare the development environment.
+
+    [:octicons-arrow-right-24: Start here](00-environment-setup/README.md)
+
+</div>
+
+## Medallion Architecture
+
+<div class="grid cards" markdown>
+
+-   :material-database-import:{ .lg .middle } __01 — Bronze Layer__
+
+    ---
+
+    Raw data ingestion with schema-on-read, append-only patterns, and source fidelity.
+
+    [:octicons-arrow-right-24: Bronze layer](01-bronze-layer/README.md)
+
+-   :material-filter:{ .lg .middle } __02 — Silver Layer__
+
+    ---
+
+    Data cleansing, validation, deduplication, and schema enforcement.
+
+    [:octicons-arrow-right-24: Silver layer](02-silver-layer/README.md)
+
+-   :material-trophy:{ .lg .middle } __03 — Gold Layer__
+
+    ---
+
+    Business aggregations, KPIs, star schema, and consumption-ready datasets.
+
+    [:octicons-arrow-right-24: Gold layer](03-gold-layer/README.md)
+
+</div>
+
+## Analytics & BI
+
+<div class="grid cards" markdown>
+
+-   :material-lightning-bolt:{ .lg .middle } __04 — Real-Time Analytics__
+
+    ---
+
+    Eventstreams, Eventhouse, KQL queries, and real-time dashboards.
+
+    [:octicons-arrow-right-24: Real-time analytics](04-real-time-analytics/README.md)
+
+-   :material-chart-areaspline:{ .lg .middle } __05 — Direct Lake & Power BI__
+
+    ---
+
+    Direct Lake connectivity, semantic models, and Power BI report design.
+
+    [:octicons-arrow-right-24: Direct Lake & BI](05-direct-lake-powerbi/README.md)
+
+-   :material-pipe:{ .lg .middle } __06 — Data Pipelines__
+
+    ---
+
+    Orchestration with pipelines, scheduling, and data movement patterns.
+
+    [:octicons-arrow-right-24: Pipelines](06-data-pipelines/README.md)
+
+-   :material-shield-check:{ .lg .middle } __07 — Governance & Purview__
+
+    ---
+
+    Microsoft Purview integration, lineage tracking, and data classification.
+
+    [:octicons-arrow-right-24: Governance](07-governance-purview/README.md)
+
+-   :material-content-copy:{ .lg .middle } __08 — Database Mirroring__
+
+    ---
+
+    Mirror external databases into Fabric OneLake for unified analytics.
+
+    [:octicons-arrow-right-24: Mirroring](08-database-mirroring/README.md)
+
+-   :material-brain:{ .lg .middle } __09 — Advanced AI/ML__
+
+    ---
+
+    Machine learning workflows, model training, and MLOps in Fabric.
+
+    [:octicons-arrow-right-24: AI/ML](09-advanced-ai-ml/README.md)
+
+</div>
+
+## Migration & Connectivity
+
+<div class="grid cards" markdown>
+
+-   :material-database-export:{ .lg .middle } __10 — Teradata Migration__
+
+    ---
+
+    Migrate from Teradata to Fabric with data validation and cutover planning.
+
+    [:octicons-arrow-right-24: Teradata migration](10-teradata-migration/README.md)
+
+-   :material-connection:{ .lg .middle } __11 — SAS Connectivity__
+
+    ---
+
+    Connect SAS datasets and integrate SAS workflows with Fabric.
+
+    [:octicons-arrow-right-24: SAS connectivity](11-sas-connectivity/README.md)
+
+-   :material-database-arrow-right:{ .lg .middle } __24 — Snowflake to Fabric__
+
+    ---
+
+    Migrate workloads from Snowflake to Microsoft Fabric.
+
+    [:octicons-arrow-right-24: Snowflake migration](24-snowflake-to-fabric/README.md)
+
+-   :material-server:{ .lg .middle } __25 — IBM DB2 Source__
+
+    ---
+
+    Ingest data from IBM DB2 into Fabric Lakehouse.
+
+    [:octicons-arrow-right-24: IBM DB2](25-ibm-db2-source/README.md)
+
+</div>
+
+## DevOps & Operations
+
+<div class="grid cards" markdown>
+
+-   :material-infinity:{ .lg .middle } __12 — CI/CD & DevOps__
+
+    ---
+
+    Git integration, deployment pipelines, and CI/CD automation.
+
+    [:octicons-arrow-right-24: CI/CD](12-cicd-devops/README.md)
+
+-   :material-map:{ .lg .middle } __13 — Migration Planning__
+
+    ---
+
+    Assessment, planning, and execution frameworks for platform migration.
+
+    [:octicons-arrow-right-24: Migration planning](13-migration-planning/README.md)
+
+-   :material-security:{ .lg .middle } __14 — Security & Networking__
+
+    ---
+
+    Network isolation, private endpoints, and security configuration.
+
+    [:octicons-arrow-right-24: Security](14-security-networking/README.md)
+
+-   :material-currency-usd:{ .lg .middle } __15 — Cost Optimization__
+
+    ---
+
+    Capacity management, auto-scale, and cost reduction strategies.
+
+    [:octicons-arrow-right-24: Cost optimization](15-cost-optimization/README.md)
+
+-   :material-speedometer:{ .lg .middle } __16 — Performance Tuning__
+
+    ---
+
+    Query optimization, caching, and compute tuning for Fabric workloads.
+
+    [:octicons-arrow-right-24: Performance](16-performance-tuning/README.md)
+
+-   :material-bell-ring:{ .lg .middle } __17 — Monitoring & Alerting__
+
+    ---
+
+    Workspace monitoring, alerting rules, and operational dashboards.
+
+    [:octicons-arrow-right-24: Monitoring](17-monitoring-alerting/README.md)
+
+-   :material-share:{ .lg .middle } __18 — Data Sharing__
+
+    ---
+
+    Cross-workspace sharing, external sharing, and data federation.
+
+    [:octicons-arrow-right-24: Data sharing](18-data-sharing/README.md)
+
+-   :material-robot:{ .lg .middle } __19 — Copilot & AI Features__
+
+    ---
+
+    AI Copilot configuration and AI-powered features in Fabric.
+
+    [:octicons-arrow-right-24: Copilot](19-copilot-ai/README.md)
+
+-   :material-folder-star:{ .lg .middle } __20 — Workspace Best Practices__
+
+    ---
+
+    Workspace organization, lifecycle management, and governance.
+
+    [:octicons-arrow-right-24: Workspace tips](20-workspace-best-practices/README.md)
+
+</div>
+
+## Networking & Gateways
+
+<div class="grid cards" markdown>
+
+-   :material-earth:{ .lg .middle } __21 — GeoAnalytics & ArcGIS__
+
+    ---
+
+    Geospatial analytics with ArcGIS integration and map visualizations.
+
+    [:octicons-arrow-right-24: GeoAnalytics](21-geoanalytics-arcgis/README.md)
+
+-   :material-lan:{ .lg .middle } __22 — Networking & Connectivity__
+
+    ---
+
+    VNet gateways, private links, and hybrid connectivity patterns.
+
+    [:octicons-arrow-right-24: Networking](22-networking-connectivity/README.md)
+
+-   :material-server-network:{ .lg .middle } __23 — SHIR & Data Gateways__
+
+    ---
+
+    Self-hosted integration runtime and on-premises data gateway setup.
+
+    [:octicons-arrow-right-24: Gateways](23-shir-data-gateways/README.md)
+
+</div>
+
+## Streaming & Analytics
+
+<div class="grid cards" markdown>
+
+-   :material-broadcast:{ .lg .middle } __26 — Multi-Source Streaming__
+
+    ---
+
+    Ingest and process streams from multiple sources with Eventstreams.
+
+    [:octicons-arrow-right-24: Streaming](26-multi-source-streaming/README.md)
+
+-   :material-cctv:{ .lg .middle } __27 — Video Security Analytics__
+
+    ---
+
+    Video feed analytics for security monitoring and incident detection.
+
+    [:octicons-arrow-right-24: Video analytics](27-video-security-analytics/README.md)
+
+-   :material-walk:{ .lg .middle } __28 — People Movement Analytics__
+
+    ---
+
+    Foot traffic, occupancy tracking, and crowd flow analysis.
+
+    [:octicons-arrow-right-24: Movement analytics](28-people-movement-analytics/README.md)
+
+-   :material-map-marker:{ .lg .middle } __29 — Geolocation Analytics__
+
+    ---
+
+    Location-based analytics, heat maps, and spatial patterns.
+
+    [:octicons-arrow-right-24: Geolocation](29-geolocation-analytics/README.md)
+
+-   :material-graph:{ .lg .middle } __37 — Graph Analytics__
+
+    ---
+
+    Network analysis, relationship mapping, and graph-based insights.
+
+    [:octicons-arrow-right-24: Graph analytics](37-graph-analytics/README.md)
+
+</div>
+
+## Federal Agency Deep Dives
+
+<div class="grid cards" markdown>
+
+-   :material-hospital:{ .lg .middle } __30 — Tribal Healthcare__
+
+    ---
+
+    HIPAA-compliant healthcare analytics with tribal sovereignty considerations.
+
+    [:octicons-arrow-right-24: Tribal healthcare](30-tribal-healthcare/README.md)
+
+-   :material-airplane:{ .lg .middle } __31 — Federal DOT/FAA__
+
+    ---
+
+    Transportation safety data, FAA analytics, and federal compliance.
+
+    [:octicons-arrow-right-24: DOT/FAA](31-federal-dot-faa/README.md)
+
+-   :material-sprout:{ .lg .middle } __32 — USDA Agriculture__
+
+    ---
+
+    Full medallion pipeline for USDA crop, livestock, and food safety data.
+
+    [:octicons-arrow-right-24: USDA](32-usda-agriculture/README.md)
+
+-   :material-store:{ .lg .middle } __33 — SBA Small Business__
+
+    ---
+
+    SBA loan programs, disaster lending, and small business analytics.
+
+    [:octicons-arrow-right-24: SBA](33-sba-small-business/README.md)
+
+-   :material-weather-partly-cloudy:{ .lg .middle } __34 — NOAA Weather & Climate__
+
+    ---
+
+    Weather observation, forecast analytics, and climate trend analysis.
+
+    [:octicons-arrow-right-24: NOAA](34-noaa-weather-climate/README.md)
+
+-   :material-leaf:{ .lg .middle } __35 — EPA Environment__
+
+    ---
+
+    Environmental monitoring, emissions data, and compliance reporting.
+
+    [:octicons-arrow-right-24: EPA](35-epa-environment/README.md)
+
+-   :material-pine-tree:{ .lg .middle } __36 — DOI Interior__
+
+    ---
+
+    Natural resource management, land use, and conservation analytics.
+
+    [:octicons-arrow-right-24: DOI](36-doi-interior/README.md)
+
+-   :material-gavel:{ .lg .middle } __38 — DOJ Justice__
+
+    ---
+
+    Justice system analytics, case management, and enforcement data.
+
+    [:octicons-arrow-right-24: DOJ](38-doj-justice/README.md)
+
+</div>
+
+## Quick Reference
+
+<div class="grid cards" markdown>
+
+-   :material-note-text:{ .lg .middle } __Cheat Sheet__
+
+    ---
+
+    Quick-reference commands, patterns, and tips for all tutorials.
+
+    [:octicons-arrow-right-24: Cheat sheet](CHEAT_SHEET.md)
+
+</div>

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -1,0 +1,178 @@
+---
+title: Use Cases
+description: Industry-specific analytics use cases built on Microsoft Fabric
+---
+
+# Use Cases
+
+Real-world analytics scenarios demonstrating Microsoft Fabric capabilities across federal agencies, regulated industries, and enterprise domains.
+
+## Federal & Government
+
+<div class="grid cards" markdown>
+
+-   :material-gavel:{ .lg .middle } __Federal Justice Analytics__
+
+    ---
+
+    DOJ case management, sentencing analytics, and justice system data pipelines.
+
+    [:octicons-arrow-right-24: Justice analytics](federal-justice-analytics.md)
+
+-   :material-scale-balance:{ .lg .middle } __Antitrust Analytics__
+
+    ---
+
+    Market concentration analysis, merger review, and competitive intelligence.
+
+    [:octicons-arrow-right-24: Antitrust analytics](antitrust-analytics.md)
+
+-   :material-airplane:{ .lg .middle } __Transportation Safety__
+
+    ---
+
+    DOT/FAA safety analytics, incident tracking, and compliance reporting.
+
+    [:octicons-arrow-right-24: Transportation safety](transportation-safety-analytics.md)
+
+-   :material-sprout:{ .lg .middle } __Agricultural Analytics__
+
+    ---
+
+    USDA crop production, food safety, and agricultural market analysis.
+
+    [:octicons-arrow-right-24: Agricultural analytics](agricultural-analytics.md)
+
+-   :material-store:{ .lg .middle } __Small Business Lending__
+
+    ---
+
+    SBA loan analytics, lending patterns, and economic impact analysis.
+
+    [:octicons-arrow-right-24: Lending analytics](small-business-lending-analytics.md)
+
+-   :material-weather-partly-cloudy:{ .lg .middle } __Weather & Climate__
+
+    ---
+
+    NOAA weather data, climate modeling, and environmental forecasting.
+
+    [:octicons-arrow-right-24: Weather analytics](weather-climate-analytics.md)
+
+-   :material-leaf:{ .lg .middle } __Environmental Compliance__
+
+    ---
+
+    EPA monitoring, emissions tracking, and environmental regulatory reporting.
+
+    [:octicons-arrow-right-24: Environmental analytics](environmental-compliance-analytics.md)
+
+-   :material-pine-tree:{ .lg .middle } __Natural Resources__
+
+    ---
+
+    DOI resource management, land use analytics, and conservation tracking.
+
+    [:octicons-arrow-right-24: Natural resources](natural-resources-analytics.md)
+
+-   :material-hospital:{ .lg .middle } __Tribal Health__
+
+    ---
+
+    HIPAA-compliant tribal healthcare analytics with 42 CFR Part 2 protections.
+
+    [:octicons-arrow-right-24: Tribal health](tribal-health-analytics.md)
+
+</div>
+
+## Cross-Industry
+
+<div class="grid cards" markdown>
+
+-   :material-heart-pulse:{ .lg .middle } __Commercial Healthcare__
+
+    ---
+
+    Healthcare operations, clinical analytics, and patient outcome tracking.
+
+    [:octicons-arrow-right-24: Healthcare ops](commercial-healthcare-operations.md)
+
+-   :material-flash:{ .lg .middle } __Energy Grid Analytics__
+
+    ---
+
+    Power grid monitoring, demand forecasting, and renewable integration.
+
+    [:octicons-arrow-right-24: Energy analytics](energy-grid-analytics.md)
+
+-   :material-credit-card:{ .lg .middle } __Financial Fraud Detection__
+
+    ---
+
+    Transaction monitoring, anomaly detection, and fraud prevention patterns.
+
+    [:octicons-arrow-right-24: Fraud detection](financial-fraud-detection.md)
+
+-   :material-shield-check:{ .lg .middle } __Insurance Claims__
+
+    ---
+
+    Claims processing analytics, risk assessment, and actuarial analysis.
+
+    [:octicons-arrow-right-24: Insurance analytics](insurance-claims-analytics.md)
+
+-   :material-factory:{ .lg .middle } __Manufacturing Predictive Maintenance__
+
+    ---
+
+    IoT sensor analytics, equipment health monitoring, and failure prediction.
+
+    [:octicons-arrow-right-24: Predictive maintenance](manufacturing-predictive-maintenance.md)
+
+-   :material-television:{ .lg .middle } __Media Audience Analytics__
+
+    ---
+
+    Audience measurement, content performance, and engagement analytics.
+
+    [:octicons-arrow-right-24: Media analytics](media-audience-analytics.md)
+
+-   :material-pill:{ .lg .middle } __Pharma Clinical Trials__
+
+    ---
+
+    Clinical trial data management, regulatory submission, and safety monitoring.
+
+    [:octicons-arrow-right-24: Clinical trials](pharma-clinical-trials.md)
+
+-   :material-cart:{ .lg .middle } __Retail Demand Forecasting__
+
+    ---
+
+    Demand prediction, inventory optimization, and supply chain analytics.
+
+    [:octicons-arrow-right-24: Retail analytics](retail-demand-forecasting.md)
+
+-   :material-cellphone-link:{ .lg .middle } __Telecom Churn & Network__
+
+    ---
+
+    Customer churn prediction, network performance, and service analytics.
+
+    [:octicons-arrow-right-24: Telecom analytics](telecom-churn-network.md)
+
+</div>
+
+## Reference
+
+<div class="grid cards" markdown>
+
+-   :material-bookshelf:{ .lg .middle } __Published References__
+
+    ---
+
+    Academic papers, industry reports, and official documentation supporting these use cases.
+
+    [:octicons-arrow-right-24: References](references/README.md)
+
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,8 +43,7 @@ theme:
     - navigation.tracking
     - navigation.tabs
     - navigation.tabs.sticky
-    - navigation.sections
-    - navigation.expand
+    - navigation.indexes
     - navigation.top
     - navigation.footer
     - search.suggest
@@ -145,6 +144,7 @@ nav:
     - AI Copilot Chat: chat.md
   
   - Getting Started:
+    - getting-started/index.md
     - Prerequisites: PREREQUISITES.md
     - Deployment: DEPLOYMENT.md
     - Cost Estimation: COST_ESTIMATION.md
@@ -155,6 +155,7 @@ nav:
     - Diagrams: diagrams/architecture-overview.md
   
   - Tutorials:
+    - tutorials/index.md
     - Overview: tutorials/README.md
     - 00 - Environment Setup: tutorials/00-environment-setup/README.md
     - 01 - Bronze Layer: tutorials/01-bronze-layer/README.md
@@ -206,6 +207,7 @@ nav:
     - Diagram Guide: poc-agenda/DIAGRAM_GUIDE.md
   
   - Use Cases:
+    - use-cases/index.md
     - Overview: use-cases/README.md
     - Antitrust Analytics: use-cases/antitrust-analytics.md
     - Federal Justice Analytics: use-cases/federal-justice-analytics.md
@@ -219,6 +221,7 @@ nav:
     - Published References: use-cases/references/README.md
 
   - Features:
+    - features/index.md
     - Fabric IQ: features/fabric-iq.md
     - Real-Time Intelligence: features/real-time-intelligence.md
     - AI Copilot: features/ai-copilot-configuration.md
@@ -256,6 +259,7 @@ nav:
     - Workspace IP Firewall: features/workspace-ip-firewall.md
 
   - Best Practices:
+    - best-practices/index.md
     - Overview: best-practices/README.md
     - Workspaces & Naming: best-practices/01_WORKSPACES_NAMING.md
     - Data Gateway: best-practices/02_DATA_GATEWAY.md
@@ -303,3 +307,19 @@ nav:
   - Infrastructure:
     - Overview: infra/README.md
     - Contributing: CONTRIBUTING.md
+
+  - Guides:
+    - Industries:
+      - Overview: guides/industries/index.md
+    - Decision Guides:
+      - Overview: guides/decisions/index.md
+    - Compliance:
+      - Overview: guides/compliance/index.md
+    - Quickstarts:
+      - Overview: guides/quickstarts/index.md
+    - Research:
+      - Overview: guides/research/index.md
+    - Runbooks:
+      - Overview: guides/runbooks/index.md
+    - Reference Architecture:
+      - Overview: guides/reference-architecture/index.md


### PR DESCRIPTION
## Summary

- Removed `navigation.expand` and `navigation.sections` from mkdocs.yml theme features
- Added `navigation.indexes` for Material section index page support
- Created Material grid card index pages for `features/`, `best-practices/`, `use-cases/`, `tutorials/`, and `getting-started/` sections
- Added Guides tab with industries, decisions, compliance, quickstarts, research, runbooks, and reference-architecture sections

## Files Changed
  - `mkdocs.yml`
  - `docs/features/index.md`
  - `docs/best-practices/index.md`
  - `docs/use-cases/index.md`
  - `docs/tutorials/index.md`
  - `docs/getting-started/index.md`

## Validation Commands
  - `cd E:/Repos/GitHub/MyDemoRepos/Suppercharge_Microsoft_Fabric && python -c "import yaml; y=yaml.safe_load(open('mkdocs.yml')); feats=y['theme']['features']; assert 'navigation.indexes' in feats; assert 'navigation.expand' not in feats; assert 'navigation.sections' not in feats; print('NAV CONFIG OK')"`

> Note: `safe_load` fails on pre-existing `!!python/name:` tags in mkdocs.yml. Use `yaml.load(open('mkdocs.yml'), Loader=yaml.BaseLoader)` instead. All assertions pass with BaseLoader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)