### PR TITLE
feat(phase15): Research & White Papers for Fabric

### DIFF
--- a/docs/research/ai-readiness-assessment.md
+++ b/docs/research/ai-readiness-assessment.md
@@ -1,0 +1,335 @@
+# AI Readiness Assessment for Microsoft Fabric
+
+> A structured framework for evaluating an organization's readiness to adopt Fabric AI capabilities — Copilot, AutoML, Semantic Link, Data Agents, and AI Functions — with a maturity model, assessment questionnaire, and implementation roadmap.
+
+## Executive Summary
+
+Microsoft Fabric's AI capabilities span a broad spectrum, from no-code Copilot assistance to advanced Data Agents that autonomously orchestrate multi-step analytics workflows. However, organizations cannot simply "turn on AI" — successful adoption requires foundational maturity in data quality, governance, infrastructure, skills, and organizational culture. This assessment framework helps enterprise leaders evaluate where they stand today and chart a realistic path to AI-powered analytics.
+
+The framework operates on five maturity levels (Aware, Exploring, Operationalizing, Scaling, Transforming) across six readiness dimensions (Data Foundation, Governance and Trust, Infrastructure, Skills and Culture, Use Case Portfolio, AI Operations). Each dimension includes specific assessment criteria, scoring guidance, and recommended actions for advancement.
+
+## AI Capability Landscape in Fabric
+
+Before assessing readiness, it is essential to understand what Fabric's AI capabilities actually offer and what they require from the organization.
+
+### Capability Tiers
+
+```mermaid
+flowchart TD
+    subgraph Tier1["Tier 1: AI-Assisted (Low Barrier)"]
+        COP[Fabric Copilot]
+        COP --> |"Natural language"| SQL1[SQL Generation]
+        COP --> |"Natural language"| DAX1[DAX Generation]
+        COP --> |"Natural language"| PBI1[Report Building]
+    end
+
+    subgraph Tier2["Tier 2: Automated ML (Medium Barrier)"]
+        AML[AutoML]
+        AML --> TRAIN[Model Training]
+        AML --> DEPLOY[Model Endpoints]
+        SL[Semantic Link]
+        SL --> ENRICH[Data Enrichment]
+    end
+
+    subgraph Tier3["Tier 3: Advanced AI (High Barrier)"]
+        DA[Data Agents]
+        DA --> ORCH[Multi-step Orchestration]
+        AIF[AI Functions]
+        AIF --> SPARK[Spark-embedded Inference]
+        VDB[Vector Database]
+        VDB --> RAG[RAG Patterns]
+    end
+
+    Tier1 --> Tier2 --> Tier3
+```
+
+**Tier 1 — AI-Assisted (Low Barrier):** Fabric Copilot provides natural language interfaces for SQL generation, DAX authoring, notebook code completion, and Power BI report building. Requirements: valid Fabric capacity, Microsoft 365 Copilot licensing, well-documented semantic models with descriptions and relationships. No custom model training required.
+
+**Tier 2 — Automated ML (Medium Barrier):** AutoML enables no-code model training for classification, regression, and forecasting directly within Fabric notebooks. Semantic Link connects Power BI semantic models with Spark notebooks for bidirectional enrichment. Requirements: clean, labeled training data in OneLake; defined business metrics; basic understanding of ML concepts; F64+ capacity for training workloads.
+
+**Tier 3 — Advanced AI (High Barrier):** Data Agents autonomously execute multi-step analytics workflows using natural language instructions. AI Functions embed pre-trained models (sentiment analysis, translation, entity extraction) directly into Spark transformations. Vector Database in Eventhouse enables retrieval-augmented generation (RAG) patterns with KQL. Requirements: mature data platform, established governance, skilled ML engineers, clear AI use cases with measurable business value, Azure OpenAI or model endpoint configuration.
+
+## Maturity Model
+
+The AI Readiness Maturity Model defines five levels that an organization progresses through on its journey from initial awareness to transformative AI adoption. Each level builds on the previous one — skipping levels creates fragile implementations that fail under production conditions.
+
+### Level 1 — Aware
+
+The organization recognizes that AI capabilities exist in Fabric but has not yet experimented with them. Data infrastructure may be nascent (raw files in ADLS, no medallion architecture). Governance is informal or absent. Analytics is primarily manual (Excel, ad-hoc SQL). There is no dedicated data science function.
+
+**Characteristics:**
+- Data stored in unstructured formats without schema enforcement
+- No centralized data catalog or lineage tracking
+- Analytics driven by individual analysts with local tools
+- AI/ML perceived as aspirational rather than actionable
+- No defined AI use cases or success metrics
+
+**Actions to advance:**
+- Establish a medallion architecture with Bronze/Silver/Gold layers
+- Deploy Microsoft Purview for data cataloging
+- Identify 2-3 candidate AI use cases with clear business value
+- Train core team on Fabric fundamentals (Lakehouse, notebooks, pipelines)
+
+### Level 2 — Exploring
+
+The organization has a working Fabric deployment with medallion architecture and is actively experimenting with Tier 1 AI capabilities (Copilot). A small team of data practitioners has explored Copilot for SQL/DAX generation. Data quality is improving but inconsistent. Governance policies exist on paper but enforcement is manual.
+
+**Characteristics:**
+- Medallion architecture implemented for at least one domain
+- Copilot enabled and used for ad-hoc query assistance
+- 1-3 data practitioners experimenting with AI features
+- Data quality issues are known but not systematically addressed
+- No production AI/ML models deployed
+- Governance relies on manual review rather than automated policy
+
+**Actions to advance:**
+- Implement automated data quality checks at Silver layer (Great Expectations or similar)
+- Add column descriptions and relationships to all semantic models (required for effective Copilot)
+- Define AI use case portfolio with business sponsors
+- Pilot one AutoML project end-to-end (training through deployment)
+- Establish data stewardship roles within business domains
+
+### Level 3 — Operationalizing
+
+The organization has deployed its first production AI/ML models and is operationalizing AI workflows. Data quality is systematically measured and enforced. Governance is automated for core datasets. Copilot usage is widespread. The first AutoML models are in production, delivering measurable business value. A data science team or function exists, even if small.
+
+**Characteristics:**
+- 1-3 production ML models deployed via AutoML or custom training
+- Systematic data quality monitoring with alerting
+- Purview governance policies enforced automatically
+- Semantic models fully documented with descriptions, relationships, and measures
+- Copilot adopted by 50%+ of analytics users
+- First measurable ROI from AI initiatives
+- Defined model monitoring and retraining cadence
+
+**Actions to advance:**
+- Implement Semantic Link for bidirectional model-to-BI enrichment
+- Build feature store patterns for reusable ML features
+- Establish MLOps practices (model versioning, A/B testing, drift detection)
+- Expand AI use case portfolio across 3+ business domains
+- Begin evaluating Data Agents for workflow automation
+
+### Level 4 — Scaling
+
+AI capabilities are deployed across multiple business domains with standardized MLOps practices. Data Agents are automating routine analytics workflows. AI Functions are embedded in production Spark transformations. The organization has a Center of Excellence (CoE) or AI platform team that provides shared infrastructure, governance, and best practices.
+
+**Characteristics:**
+- 10+ production ML models across multiple domains
+- Data Agents handling routine analytics tasks
+- AI Functions embedded in production data pipelines
+- Formal MLOps practices: model registry, versioning, monitoring, retraining automation
+- Center of Excellence providing shared AI infrastructure
+- Cross-domain feature store with governed sharing
+- Measured business impact across multiple KPIs
+
+**Actions to advance:**
+- Implement RAG patterns using Eventhouse Vector Database for domain-specific AI assistants
+- Build self-service AI capabilities for business users (no-code model training, guided agent creation)
+- Integrate AI outputs into operational systems (not just analytics)
+- Develop AI governance framework (bias detection, explainability, compliance)
+- Evaluate custom foundation model fine-tuning for domain-specific tasks
+
+### Level 5 — Transforming
+
+AI is a core capability that transforms how the organization operates, competes, and creates value. AI-driven insights flow directly into operational decisions. Custom AI agents handle complex multi-step workflows autonomously. The organization contributes to the AI ecosystem (shared models, published research, community participation).
+
+**Characteristics:**
+- AI embedded in operational decision-making, not just analytics
+- Custom-trained domain models deployed alongside pre-trained services
+- Self-service AI capabilities available to business users across all domains
+- AI governance framework with bias detection, explainability, and compliance auditing
+- Continuous experimentation culture with rapid AI use case prototyping
+- Organization recognized as an AI leader in its industry
+
+## Assessment Questionnaire
+
+Score each dimension on a 1-5 scale corresponding to the maturity levels above. Average scores across dimensions to determine overall readiness level.
+
+### Dimension 1: Data Foundation
+
+| # | Assessment Question | Score (1-5) |
+|---|-------------------|-------------|
+| 1.1 | Is data organized in a medallion architecture (Bronze/Silver/Gold) with schema enforcement? | |
+| 1.2 | Are automated data quality checks running at each layer with alerting on failures? | |
+| 1.3 | Is data cataloged with business descriptions, data types, and sensitivity classifications? | |
+| 1.4 | Are historical datasets available with sufficient volume for ML training (thousands+ rows per target)? | |
+| 1.5 | Is data freshness measured and SLAs defined for key datasets? | |
+| 1.6 | Are feature engineering patterns standardized and reusable across use cases? | |
+
+**Scoring guide:** Score 1 if data is in raw files with no schema. Score 3 if medallion architecture exists for core domains with basic quality checks. Score 5 if all production datasets are quality-validated, cataloged, and available for ML training with feature store patterns.
+
+### Dimension 2: Governance and Trust
+
+| # | Assessment Question | Score (1-5) |
+|---|-------------------|-------------|
+| 2.1 | Are data access policies automated (not manual spreadsheet-based tracking)? | |
+| 2.2 | Is data lineage tracked end-to-end from source to dashboard? | |
+| 2.3 | Are sensitivity labels applied to datasets containing PII, PHI, or financial data? | |
+| 2.4 | Is there a defined process for approving AI model deployment to production? | |
+| 2.5 | Are AI model outputs monitored for bias, drift, and accuracy degradation? | |
+| 2.6 | Does a responsible AI framework exist with documented principles and review processes? | |
+
+**Scoring guide:** Score 1 if governance is informal with no tooling. Score 3 if Purview is deployed with basic policies. Score 5 if governance is fully automated with sensitivity labels, lineage, model approval workflows, and responsible AI reviews.
+
+### Dimension 3: Infrastructure
+
+| # | Assessment Question | Score (1-5) |
+|---|-------------------|-------------|
+| 3.1 | Is Fabric capacity (F64+) provisioned with auto-scale or burst capabilities? | |
+| 3.2 | Are development, staging, and production workspaces separated with CI/CD? | |
+| 3.3 | Is network security configured (private endpoints, managed VNet, outbound access protection)? | |
+| 3.4 | Are monitoring dashboards tracking CU utilization, query performance, and pipeline health? | |
+| 3.5 | Is disaster recovery configured with documented RTO/RPO targets? | |
+| 3.6 | Are Azure OpenAI or model endpoints provisioned and accessible from Fabric? | |
+
+**Scoring guide:** Score 1 if running on trial capacity with no environment separation. Score 3 if F64 with dev/prod separation and basic monitoring. Score 5 if multi-capacity with auto-scale, full CI/CD, network isolation, DR, and Azure OpenAI endpoints configured.
+
+### Dimension 4: Skills and Culture
+
+| # | Assessment Question | Score (1-5) |
+|---|-------------------|-------------|
+| 4.1 | Do data engineers understand medallion architecture, Delta Lake, and Spark? | |
+| 4.2 | Are BI developers proficient with semantic models, DAX, and Copilot? | |
+| 4.3 | Does the team include members with ML/AI experience (model training, evaluation, deployment)? | |
+| 4.4 | Is there a culture of experimentation where teams can prototype AI use cases? | |
+| 4.5 | Are business stakeholders engaged as AI use case sponsors with defined success metrics? | |
+| 4.6 | Is there a learning budget and time allocation for AI skill development? | |
+
+**Scoring guide:** Score 1 if the team has no Fabric or AI experience. Score 3 if core data engineering and BI skills exist with 1-2 ML-skilled members. Score 5 if a cross-functional AI team exists with business sponsorship, experimentation culture, and continuous learning.
+
+### Dimension 5: Use Case Portfolio
+
+| # | Assessment Question | Score (1-5) |
+|---|-------------------|-------------|
+| 5.1 | Are AI use cases identified with clear business value and measurable KPIs? | |
+| 5.2 | Is there a prioritized backlog of AI initiatives ranked by value/feasibility? | |
+| 5.3 | Has at least one AI use case been deployed to production with measured results? | |
+| 5.4 | Are use cases mapped to specific Fabric AI capabilities (Copilot, AutoML, Agents, etc.)? | |
+| 5.5 | Is there a process for evaluating new AI use cases (idea → feasibility → pilot → production)? | |
+| 5.6 | Are AI use cases aligned with organizational strategic priorities? | |
+
+**Scoring guide:** Score 1 if no use cases are defined. Score 3 if 3-5 use cases are identified with business sponsors. Score 5 if a portfolio of 10+ use cases exists across domains with measured production results and a continuous intake process.
+
+### Dimension 6: AI Operations (AIOps)
+
+| # | Assessment Question | Score (1-5) |
+|---|-------------------|-------------|
+| 6.1 | Is model training automated with version control and reproducibility? | |
+| 6.2 | Are production models monitored for accuracy, latency, and data drift? | |
+| 6.3 | Is there an automated retraining pipeline triggered by performance degradation? | |
+| 6.4 | Are AI costs tracked and attributed to business domains or use cases? | |
+| 6.5 | Is there a rollback procedure for reverting to previous model versions? | |
+| 6.6 | Are AI system SLAs defined and measured (availability, response time, accuracy)? | |
+
+**Scoring guide:** Score 1 if no MLOps practices exist. Score 3 if basic model versioning and manual monitoring are in place. Score 5 if fully automated MLOps with drift detection, auto-retraining, cost attribution, and SLA monitoring.
+
+## Scoring and Interpretation
+
+### Overall Readiness Score
+
+Calculate the average score across all six dimensions to determine overall readiness level:
+
+| Average Score | Readiness Level | Recommended Starting Point |
+|--------------|----------------|---------------------------|
+| 1.0 - 1.5 | Level 1 — Aware | Start with data foundation (medallion architecture, Purview) before any AI |
+| 1.5 - 2.5 | Level 2 — Exploring | Enable Copilot, pilot AutoML on one clean dataset |
+| 2.5 - 3.5 | Level 3 — Operationalizing | Deploy production ML models, implement Semantic Link, begin Data Agents evaluation |
+| 3.5 - 4.5 | Level 4 — Scaling | Scale AI across domains, implement RAG patterns, build self-service AI |
+| 4.5 - 5.0 | Level 5 — Transforming | Custom model training, operational AI integration, industry leadership |
+
+### Readiness Radar
+
+Visualize your scores across dimensions to identify strengths and gaps. Dimensions with the lowest scores are your blockers — address them before advancing to higher AI capability tiers.
+
+```mermaid
+flowchart LR
+    subgraph Assessment["Readiness Dimensions"]
+        direction TB
+        D1[Data Foundation] --> Score1[Score: ?/5]
+        D2[Governance & Trust] --> Score2[Score: ?/5]
+        D3[Infrastructure] --> Score3[Score: ?/5]
+        D4[Skills & Culture] --> Score4[Score: ?/5]
+        D5[Use Case Portfolio] --> Score5[Score: ?/5]
+        D6[AI Operations] --> Score6[Score: ?/5]
+    end
+
+    Assessment --> AVG[Average Score]
+    AVG --> Level[Readiness Level]
+    Level --> Roadmap[Implementation Roadmap]
+```
+
+## Implementation Roadmap
+
+Based on assessment results, follow the roadmap corresponding to your current readiness level.
+
+### From Level 1 to Level 2 (3-6 months)
+
+**Focus: Build the data foundation.**
+
+| Month | Actions |
+|-------|---------|
+| 1-2 | Deploy Fabric capacity (F64), create dev/prod workspaces, implement Bronze layer for 2-3 source systems |
+| 2-3 | Implement Silver layer with schema enforcement and basic data quality checks |
+| 3-4 | Deploy Purview, begin cataloging datasets with descriptions and sensitivity labels |
+| 4-5 | Implement Gold layer with business KPIs, deploy first Power BI semantic model with Copilot |
+| 5-6 | Enable Copilot for BI team, identify 3 candidate AI use cases, complete team training on Fabric fundamentals |
+
+### From Level 2 to Level 3 (6-9 months)
+
+**Focus: Operationalize first AI models.**
+
+| Month | Actions |
+|-------|---------|
+| 1-3 | Implement Great Expectations data quality suites for Silver layer, enrich semantic models with full descriptions |
+| 3-5 | Pilot AutoML for top-priority use case (classification or forecasting), deploy to production endpoint |
+| 5-7 | Implement Semantic Link for bidirectional model-to-BI integration |
+| 7-8 | Establish basic MLOps (model versioning, manual monitoring, retraining schedule) |
+| 8-9 | Measure and report ROI from first production AI model, expand to second use case |
+
+### From Level 3 to Level 4 (9-12 months)
+
+**Focus: Scale AI across domains.**
+
+| Month | Actions |
+|-------|---------|
+| 1-3 | Build feature store patterns, standardize model training pipelines across domains |
+| 3-5 | Implement Data Agents for routine analytics automation |
+| 5-7 | Embed AI Functions in production Spark transformations (sentiment, entity extraction) |
+| 7-9 | Establish Center of Excellence with shared AI infrastructure and governance |
+| 9-12 | Deploy 10+ models, implement automated drift detection and retraining |
+
+### From Level 4 to Level 5 (12-18 months)
+
+**Focus: Transform with AI.**
+
+| Month | Actions |
+|-------|---------|
+| 1-4 | Implement RAG patterns using Eventhouse Vector Database for domain-specific AI assistants |
+| 4-8 | Build self-service AI platform for business users |
+| 8-12 | Integrate AI outputs into operational decision systems |
+| 12-15 | Develop responsible AI governance framework with bias detection and explainability |
+| 15-18 | Evaluate custom foundation model fine-tuning for domain-specific tasks |
+
+## Common Anti-Patterns
+
+Avoid these common mistakes when pursuing AI readiness:
+
+**Skipping the data foundation.** Organizations that jump to AI model training before establishing clean, governed data invariably produce models that fail in production. Low-quality input data produces low-quality predictions regardless of algorithm sophistication. Always build the medallion architecture and data quality framework first.
+
+**Over-investing in infrastructure before validating use cases.** Provisioning GPU clusters and Azure OpenAI endpoints before identifying concrete use cases with business sponsors leads to expensive idle infrastructure. Start with Fabric's built-in capabilities (Copilot, AutoML) which require no additional infrastructure and validate business value before scaling.
+
+**Treating AI as an IT project rather than a business initiative.** AI use cases succeed when business stakeholders own the problem definition, success metrics, and adoption. IT provides the platform and engineering; the business provides the domain expertise and change management. Without business sponsorship, even technically excellent models fail to deliver value.
+
+**Ignoring governance until production.** Retrofitting data governance, model approval workflows, and responsible AI practices after models are in production is significantly harder and riskier than building them in from the start. Establish governance frameworks alongside your first production model, not after your tenth.
+
+**Pursuing too many use cases simultaneously.** Organizations that spread thin across 10+ AI initiatives without deep investment in any single one rarely achieve production deployment. Focus on 2-3 high-value use cases, prove ROI, and then expand with the credibility and operational patterns established by early wins.
+
+## Related Documentation
+
+- [AutoML Model Endpoints](../features/automl-model-endpoints.md) — No-code ML training in Fabric
+- [Fabric Copilot & AI](../features/fabric-iq.md) — Copilot capabilities and configuration
+- [Data Agents](../features/data-agents.md) — Autonomous analytics agents
+- [Semantic Link](../features/semantic-link.md) — BI-to-Spark bidirectional integration
+- [AI Functions Compliance](../notebooks/gold/17_gold_ai_functions_compliance.py) — Embedding AI in Spark transformations
+- [Eventhouse Vector Database](../features/eventhouse-vector-database.md) — RAG patterns with KQL
+- [Testing Strategies](../best-practices/testing-strategies.md) — Including ML model validation

--- a/docs/research/data-mesh-maturity-model.md
+++ b/docs/research/data-mesh-maturity-model.md
@@ -1,0 +1,389 @@
+# Data Mesh Maturity Model on Microsoft Fabric
+
+> How to implement Data Mesh principles using Fabric constructs — workspaces as domains, OneLake as federated storage, Purview as the governance plane, and data products delivered via lakehouses and semantic models. Includes maturity levels, assessment criteria, and a migration path from centralized to mesh.
+
+## Executive Summary
+
+Data Mesh is an organizational and architectural paradigm that treats data as a product, owned and operated by the business domains that produce it, rather than centrally managed by a monolithic data team. The four pillars of Data Mesh — domain-oriented ownership, data as a product, self-serve data infrastructure, and federated computational governance — map naturally onto Microsoft Fabric's architecture, but successful implementation requires deliberate organizational change alongside technical configuration.
+
+This paper provides a maturity model for organizations adopting Data Mesh principles on Fabric, a detailed mapping of Mesh concepts to Fabric constructs, assessment criteria for each maturity level, and a migration path from centralized analytics architectures to a federated mesh. The framework is practical rather than dogmatic — recognizing that most enterprises will adopt a hybrid approach with centralized infrastructure and federated ownership, rather than a pure mesh from day one.
+
+## Data Mesh Principles Mapped to Fabric
+
+Each Data Mesh principle has a direct implementation path in Microsoft Fabric. Understanding these mappings is the foundation for the maturity model.
+
+### Principle 1: Domain-Oriented Ownership
+
+In Data Mesh, data is owned by the business domain that produces it. The sales team owns sales data; the manufacturing team owns production telemetry; the finance team owns financial reporting datasets.
+
+**Fabric implementation:** Each domain gets its own Fabric workspace (or set of workspaces for dev/test/prod environments). The workspace is the boundary of ownership — the domain team controls what data products are created, how they are transformed, and when they are refreshed. Workspace roles (Admin, Member, Contributor, Viewer) map to domain team members.
+
+```mermaid
+flowchart TD
+    subgraph Platform["Fabric Tenant"]
+        subgraph Sales["Sales Domain"]
+            SW[Sales Workspace]
+            SLH[Sales Lakehouse]
+            SSM[Sales Semantic Model]
+        end
+
+        subgraph Mfg["Manufacturing Domain"]
+            MW[Mfg Workspace]
+            MLH[Mfg Lakehouse]
+            MSM[Mfg Semantic Model]
+        end
+
+        subgraph Finance["Finance Domain"]
+            FW[Finance Workspace]
+            FLH[Finance Lakehouse]
+            FSM[Finance Semantic Model]
+        end
+
+        OL[OneLake]
+        PV[Microsoft Purview]
+
+        SLH --> OL
+        MLH --> OL
+        FLH --> OL
+        OL --> PV
+    end
+
+    Sales -.->|Shortcut| Finance
+    Mfg -.->|Shortcut| Finance
+```
+
+**Key Fabric features:**
+- Workspaces provide the organizational boundary for domain ownership
+- Workspace Identity enables domain-level service principal authentication
+- Workspace tags enable metadata-driven management and discovery across domains
+- OneLake shortcuts enable cross-domain data access without duplication
+
+### Principle 2: Data as a Product
+
+Data Mesh treats datasets as products with defined quality standards, SLAs, discoverability, and documentation — just like software products. Domain teams are responsible for ensuring their data products meet consumer expectations.
+
+**Fabric implementation:** A data product in Fabric is typically a Gold-layer Lakehouse table or a Power BI semantic model that is published, documented, and governed for consumption by other domains. Data products are discoverable via OneLake Catalog and governed via Purview sensitivity labels and access policies.
+
+**Data product attributes and Fabric implementations:**
+
+| Attribute | Description | Fabric Implementation |
+|-----------|-------------|----------------------|
+| Discoverable | Consumers can find the product without asking the producer | OneLake Catalog with descriptions, tags, endorsement badges |
+| Addressable | Consumers can access the product via a stable, documented interface | OneLake shortcuts (stable paths), semantic model connection strings |
+| Trustworthy | Quality is measured, monitored, and SLA-bound | Great Expectations suites, data quality KPIs in Gold dashboards |
+| Self-describing | Schema, lineage, and business context are embedded | Purview data catalog, semantic model descriptions, Lakehouse schema annotations |
+| Interoperable | Products follow shared standards for schema, format, and semantics | Delta Parquet format, shared date/entity dimension conventions, Lakehouse schemas |
+| Secure | Access is governed by policy, not ad-hoc permissions | Purview access policies, OneLake Security (table/column level), sensitivity labels |
+
+### Principle 3: Self-Serve Data Infrastructure
+
+Data Mesh requires a platform that enables domain teams to create, deploy, and operate data products without deep infrastructure expertise. The platform team provides the tools; domain teams use them.
+
+**Fabric implementation:** Fabric is inherently a self-serve platform — domain teams can create lakehouses, notebooks, pipelines, and semantic models within their workspaces without provisioning infrastructure. The platform team manages capacity allocation, network security, governance policies, and CI/CD templates.
+
+**Platform team responsibilities:**
+- Provision and manage Fabric capacities (sizing, scaling, cost allocation)
+- Configure tenant-level security (conditional access, network isolation, CMK)
+- Maintain Purview governance hub (sensitivity labels, classification rules, access policies)
+- Provide CI/CD templates and deployment pipelines (fabric-cicd)
+- Define shared conventions (naming standards, medallion architecture templates, schema standards)
+- Monitor platform health (CU utilization, throttling, capacity alerts)
+
+**Domain team responsibilities:**
+- Create and maintain domain-specific lakehouses, notebooks, and pipelines
+- Define and publish data products (Gold tables, semantic models)
+- Enforce data quality standards for their products
+- Document data products in OneLake Catalog
+- Manage domain-level access and permissions
+- Respond to consumer feedback and data quality incidents
+
+### Principle 4: Federated Computational Governance
+
+Governance in Data Mesh is federated — global policies are set centrally, but enforcement and domain-specific policies are managed by each domain. This avoids both the bottleneck of centralized governance and the chaos of ungoverned domain autonomy.
+
+**Fabric implementation:**
+
+| Governance Layer | Scope | Fabric Implementation |
+|-----------------|-------|----------------------|
+| Global policies | Tenant-wide | Purview sensitivity labels, default domain policies, CMK, network security |
+| Domain policies | Per workspace | Workspace roles, domain-specific Purview policies, data quality SLAs |
+| Product policies | Per data product | Column-level security, row-level security, endorsement badges, access requests |
+| Audit and compliance | Cross-domain | Purview audit logs, SQL audit logs, workspace monitoring |
+
+## Maturity Model
+
+The Data Mesh Maturity Model defines five levels that reflect an organization's progress from centralized analytics to a fully federated data mesh. Most enterprises will stabilize at Level 3 or Level 4 — achieving Level 5 requires significant organizational transformation beyond technology changes.
+
+### Level 1 — Centralized Monolith
+
+All data is managed by a central data team. Business domains submit requests to the data team for new datasets, reports, and integrations. The central team owns the entire data lifecycle from ingestion to BI. There is a single shared workspace (or a small number of workspaces organized by layer rather than domain).
+
+**Characteristics:**
+- Single data team manages all data assets
+- Workspaces organized by layer (bronze-ws, silver-ws, gold-ws) not by domain
+- Business teams consume reports but do not own or manage data
+- All ETL/ELT pipelines maintained centrally
+- Governance is centralized but often informal (no Purview, no sensitivity labels)
+- Data quality is the central team's responsibility
+- Change requests go through a shared backlog with multi-week lead times
+
+**Assessment criteria:**
+
+| Criterion | Level 1 Indicator |
+|-----------|-------------------|
+| Workspace structure | Organized by layer, not domain |
+| Data ownership | Central team owns everything |
+| Time to new data product | Weeks to months (backlog-dependent) |
+| Governance | Informal or centralized without tooling |
+| Domain team autonomy | None — consumers only |
+| Data product catalog | Nonexistent |
+
+### Level 2 — Domain-Aware Centralized
+
+The central data team has begun organizing data by business domain, but ownership remains centralized. Workspaces may be partially restructured by domain. Some domain teams have "embedded" analysts who work closely with the central team. Data quality awareness is growing, but enforcement remains inconsistent.
+
+**Characteristics:**
+- Workspaces partially restructured by domain (sales-ws, manufacturing-ws)
+- Central team still manages pipelines and infrastructure
+- Embedded domain analysts contribute to data modeling
+- Purview deployed for discovery, but governance policies are nascent
+- Data products are identified but not formally defined or published
+- Some domains have begun defining data quality expectations
+
+**Assessment criteria:**
+
+| Criterion | Level 2 Indicator |
+|-----------|-------------------|
+| Workspace structure | Partially domain-aligned |
+| Data ownership | Central team with domain input |
+| Time to new data product | Weeks (partially streamlined) |
+| Governance | Purview deployed, policies forming |
+| Domain team autonomy | Advisory role |
+| Data product catalog | Informal (spreadsheets, wiki) |
+
+### Level 3 — Federated Ownership
+
+Domain teams own their data products. Each domain has its own workspace with dedicated team members who create and maintain lakehouses, notebooks, and semantic models. The platform team provides shared infrastructure, governance policies, and CI/CD templates. Cross-domain data access uses OneLake shortcuts. Data products are published in OneLake Catalog with descriptions and endorsement badges.
+
+**Characteristics:**
+- Each domain has dedicated Fabric workspaces
+- Domain teams own and operate their data pipelines
+- Platform team manages capacity, security, and governance framework
+- OneLake Catalog used for data product discovery
+- Purview sensitivity labels and access policies enforced
+- Data quality SLAs defined for published data products
+- Cross-domain access via shortcuts with governed permissions
+- CI/CD pipelines (fabric-cicd) deployed per domain
+- Time to new data product: days, not weeks
+
+**Assessment criteria:**
+
+| Criterion | Level 3 Indicator |
+|-----------|-------------------|
+| Workspace structure | Domain-aligned with dev/prod separation |
+| Data ownership | Domain teams own their products |
+| Time to new data product | Days (domain autonomy) |
+| Governance | Federated — global + domain policies |
+| Domain team autonomy | Full ownership with platform guardrails |
+| Data product catalog | OneLake Catalog with descriptions |
+
+### Level 4 — Productized Mesh
+
+Data products are formally defined, measured, and continuously improved. Each data product has an owner, a quality SLA, usage metrics, and a consumer feedback loop. Cross-domain data products (shared dimensions, reference data) are managed by a dedicated governance function. Self-serve data infrastructure is mature — domain teams can provision new data products using platform templates without platform team intervention.
+
+**Characteristics:**
+- Formal data product definitions with owner, SLA, quality metrics
+- Usage analytics tracked per data product (who consumes what, how often)
+- Consumer feedback loops (data product satisfaction surveys, issue tracking)
+- Cross-domain shared dimensions managed by governance function
+- Platform templates enable self-serve data product creation
+- Automated data quality monitoring with alerting to domain owners
+- Data contracts between producer and consumer domains
+- Cost allocation per domain workspace
+
+**Assessment criteria:**
+
+| Criterion | Level 4 Indicator |
+|-----------|-------------------|
+| Workspace structure | Domain workspaces with self-serve provisioning |
+| Data ownership | Domain-owned with formal product definitions |
+| Time to new data product | Hours (template-driven) |
+| Governance | Automated with data contracts |
+| Domain team autonomy | Full self-serve with platform templates |
+| Data product catalog | Rich catalog with usage metrics and SLAs |
+
+### Level 5 — Transformative Mesh
+
+Data Mesh is embedded in organizational culture. Data products are treated as first-class business assets with budgets, roadmaps, and product managers. The platform is fully self-serve with automated compliance. Data flows seamlessly across domains via well-governed interfaces. The organization's data mesh enables new business models, partnerships, and revenue streams built on data products.
+
+**Characteristics:**
+- Data products have dedicated product managers and roadmaps
+- Data product revenue or cost-recovery models in place
+- External data sharing via governed marketplace patterns
+- AI/ML models consumed and produced as data products
+- Platform fully self-serve with automated compliance
+- Data mesh enables new business capabilities and partnerships
+- Continuous improvement driven by product metrics and consumer feedback
+
+## Migration Path: Centralized to Mesh
+
+The following migration plan guides organizations from a Level 1 centralized monolith to a Level 3 federated mesh. The journey to Level 4 and 5 is organization-specific and depends on business context.
+
+### Phase 1: Foundation (Months 1-3)
+
+**Goal:** Establish platform infrastructure and identify pilot domains.
+
+| Action | Details |
+|--------|---------|
+| Select 2 pilot domains | Choose domains with engaged business stakeholders, clean source data, and well-understood analytics requirements |
+| Create domain workspaces | One workspace per domain per environment (dev, prod) |
+| Deploy Purview | Configure data catalog, sensitivity labels, and basic access policies |
+| Define naming conventions | Workspace naming (`{domain}-{env}`), lakehouse naming (`lh_{layer}`), table naming (`{layer}_{domain}_{entity}`) |
+| Create platform templates | Lakehouse structure, notebook templates, pipeline patterns, CI/CD configuration |
+| Identify initial data products | 2-3 data products per pilot domain |
+
+### Phase 2: Pilot Domains (Months 3-6)
+
+**Goal:** Migrate pilot domains from centralized to domain ownership.
+
+| Action | Details |
+|--------|---------|
+| Transfer pipeline ownership | Move existing ETL/ELT for pilot domains from central team to domain teams |
+| Implement medallion per domain | Bronze → Silver → Gold within each domain workspace |
+| Create OneLake shortcuts | Enable cross-domain access for shared reference data |
+| Publish data products | Register in OneLake Catalog with descriptions, endorsement badges |
+| Define quality SLAs | Set data freshness, completeness, and accuracy targets per data product |
+| Train domain teams | Fabric fundamentals, data product ownership, governance responsibilities |
+| Establish feedback loops | Consumer satisfaction measurement, issue tracking per data product |
+
+### Phase 3: Scale (Months 6-12)
+
+**Goal:** Expand mesh to all domains, standardize governance.
+
+| Action | Details |
+|--------|---------|
+| Onboard remaining domains | Apply patterns from pilot to all business domains |
+| Implement data contracts | Define producer-consumer agreements for critical data products |
+| Automate governance | Purview policies applied automatically to new workspaces and data products |
+| Deploy monitoring | Data quality dashboards, CU utilization per domain, product usage analytics |
+| Establish governance council | Cross-domain forum for shared standards, dispute resolution, policy updates |
+| Implement cost allocation | Attribute Fabric capacity costs to domain workspaces |
+
+### Phase 4: Optimize (Months 12-18)
+
+**Goal:** Mature the mesh with self-serve and advanced capabilities.
+
+```mermaid
+flowchart LR
+    subgraph Phase1["Phase 1: Foundation"]
+        P1A[Platform Setup]
+        P1B[Pilot Selection]
+        P1C[Purview Deploy]
+    end
+
+    subgraph Phase2["Phase 2: Pilot"]
+        P2A[Domain Migration]
+        P2B[Data Products]
+        P2C[Quality SLAs]
+    end
+
+    subgraph Phase3["Phase 3: Scale"]
+        P3A[All Domains]
+        P3B[Data Contracts]
+        P3C[Governance Council]
+    end
+
+    subgraph Phase4["Phase 4: Optimize"]
+        P4A[Self-Serve]
+        P4B[Advanced Features]
+        P4C[Continuous Improvement]
+    end
+
+    Phase1 --> Phase2 --> Phase3 --> Phase4
+```
+
+## Organizational Considerations
+
+Data Mesh is at least as much an organizational change as it is a technical one. Technology alone does not create a mesh — you must also address ownership structures, incentive models, and cultural norms.
+
+### Team Structure
+
+The shift from centralized to mesh requires rethinking team structures. In a centralized model, there is one data team that does everything. In a mesh, there are three types of teams:
+
+**Domain data teams** own and operate data products for their business domain. These teams typically include a data engineer (pipelines, data quality), a data analyst (semantic models, reports), and a domain expert (business rules, quality validation). Domain data teams report to domain leadership (e.g., VP of Sales), not to a central data organization.
+
+**Platform team** provides and maintains the shared Fabric infrastructure. This team manages capacity, security, governance configuration, CI/CD templates, and platform monitoring. The platform team serves domain teams as an internal product team — their "customers" are the domain data teams, and their success is measured by domain team satisfaction and self-serve adoption rates.
+
+**Governance council** is a cross-domain forum that sets global standards, resolves conflicts, and evolves governance policies. Membership includes representatives from each domain and the platform team. The council owns shared conventions (naming, schema standards, quality thresholds) and adjudicates cross-domain data product disputes.
+
+### Change Management
+
+The most common failure mode for Data Mesh adoption is insufficient change management. Technical infrastructure can be deployed in months, but shifting ownership models and cultural norms takes years. Key change management actions include executive sponsorship at the C-suite level (not just CIO — the business must sponsor the shift to domain ownership), clear articulation of what changes for each role (domain leaders gain ownership and accountability, central data team evolves into platform team), gradual transition with pilot domains proving the model before full rollout, and success metrics that demonstrate value to both technology and business stakeholders.
+
+### Incentive Alignment
+
+Domain teams will not invest in data product quality unless their incentive structures reward it. Traditional incentive models focus on domain-specific KPIs (revenue, production output, customer satisfaction) without any data product metrics. Effective mesh incentive models include data product quality metrics in domain team performance reviews, recognize domain teams that publish well-consumed data products, allocate data product costs to domain budgets (creating accountability for efficiency), and track data product satisfaction scores from consumer domains.
+
+## Anti-Patterns to Avoid
+
+**Mesh in name only.** Renaming workspaces from "bronze-ws" to "sales-ws" without transferring actual ownership to domain teams. If the central data team still manages all pipelines, you have a renamed monolith, not a mesh.
+
+**Ungoverned chaos.** Giving domain teams full autonomy without shared conventions, quality standards, or governance policies. This produces incompatible data products, duplicated entities, and inconsistent definitions.
+
+**Over-engineering the platform.** Building a sophisticated self-serve platform before validating that domain teams want self-serve. Start with simple templates and manual onboarding; automate based on observed patterns.
+
+**Ignoring shared domains.** Some data (customer master, product catalog, reference data) doesn't belong to any single business domain. Failing to assign clear ownership for shared domains creates gaps and conflicts.
+
+**Big-bang migration.** Attempting to migrate all domains simultaneously overwhelms the organization. The recommended approach is to pilot with 2 domains, learn, and then scale domain by domain.
+
+**Treating mesh as permanent.** Organizational structures evolve. Some domains may be too small to sustain their own data team and should share resources. The mesh should be pragmatic, not dogmatic — adjust the model to fit the organization, not the other way around.
+
+## Fabric-Specific Implementation Patterns
+
+### Pattern 1: Domain Workspace Topology
+
+Each domain gets a workspace set: `{domain}-dev`, `{domain}-prod`. Within each workspace, a standard Lakehouse structure is provisioned via platform templates.
+
+The standard structure includes `lh_bronze` for raw ingestion from domain source systems, `lh_silver` for cleansed and validated domain data, and `lh_gold` for published data products consumed by other domains and BI. Lakehouse schemas (available in Fabric GA) organize tables within each lakehouse by subdomain or entity group.
+
+### Pattern 2: Cross-Domain Data Access
+
+When domain B needs data from domain A, the preferred pattern is OneLake shortcuts rather than data duplication. Domain A publishes a Gold table as a data product. Domain B creates a shortcut in its own lakehouse pointing to domain A's Gold table. Data stays in domain A's OneLake storage. Purview access policies control who can create shortcuts to what. No data movement, no duplication, no freshness lag.
+
+For scenarios requiring transformation of source domain data, domain B creates a pipeline that reads from domain A's shortcut and writes to domain B's Silver or Gold layer. The shortcut source and the transforming pipeline are clearly separated, maintaining lineage.
+
+### Pattern 3: Shared Dimension Management
+
+Shared dimensions (date, geography, customer, product) are managed by a dedicated "shared-data" workspace owned by the governance council or platform team. Domain workspaces create shortcuts to shared dimensions. Changes to shared dimensions follow a formal change management process (governance council approval, backward compatibility assessment, consumer notification).
+
+### Pattern 4: Data Product Endorsement
+
+Fabric supports endorsement badges (Promoted, Certified) on semantic models and lakehouses. Use a two-tier endorsement model: "Promoted" is applied by the domain team when a data product is ready for consumption. "Certified" is applied by the governance council after formal quality assessment. Consumers can filter OneLake Catalog by endorsement level to find trusted data products.
+
+## Assessment Checklist
+
+Use this checklist to assess your current maturity level and identify gaps.
+
+| # | Assessment Item | Level 1 | Level 2 | Level 3 | Level 4 | Level 5 |
+|---|----------------|---------|---------|---------|---------|---------|
+| 1 | Workspace organization | By layer | Partially by domain | Fully by domain | Self-serve provisioning | Automated lifecycle |
+| 2 | Data ownership | Central team | Central with domain input | Domain teams | Domain teams with product managers | Revenue-generating products |
+| 3 | Data product catalog | None | Informal | OneLake Catalog | Catalog with metrics | Marketplace |
+| 4 | Quality enforcement | Ad-hoc | Manual checks | Automated monitoring | SLA-bound with contracts | Continuous improvement |
+| 5 | Cross-domain access | Copy/export | Shared database | OneLake shortcuts | Governed shortcuts with contracts | Self-serve with audit |
+| 6 | Governance model | Informal | Centralized | Federated | Automated | Self-healing |
+| 7 | Platform team | None | Informal | Established | Product-oriented | Platform-as-a-product |
+| 8 | Domain team skills | None | Basic | Proficient | Self-sufficient | Innovating |
+| 9 | Cost model | Unattributed | Partially attributed | Domain-attributed | Product-attributed | Value-based |
+| 10 | Time to new data product | Months | Weeks | Days | Hours | Minutes |
+
+## Related Documentation
+
+- [Data Mesh](../features/data-mesh.md) — Fabric's Data Mesh capabilities
+- [OneLake Security](../features/onelake-security.md) — Table and column-level security
+- [OneLake Catalog](../features/onelake-catalog.md) — Data product discovery
+- [Multi-Tenant Workspace Architecture](../best-practices/multi-tenant-workspace-architecture.md) — Workspace topology patterns
+- [Data Sharing & Federation](../best-practices/data-sharing-federation.md) — Cross-domain access patterns
+- [Identity & RBAC Patterns](../best-practices/identity-rbac-patterns.md) — Workspace role management
+- [Workspace Topology Decision Tree](../decisions/workspace-topology.md) — Interactive architecture decision guide
+- [Large Enterprise Multi-Domain Architecture](../reference-architecture/large-enterprise-multi-domain.md) — Reference architecture for mesh deployments

--- a/docs/research/enterprise-data-platform-comparison.md
+++ b/docs/research/enterprise-data-platform-comparison.md
@@ -1,0 +1,279 @@
+# Enterprise Data Platform Comparison 2026
+
+> Fabric vs Databricks vs Snowflake vs Synapse Analytics — a structured comparison to guide platform selection for enterprise analytics, data engineering, and AI workloads.
+
+## Executive Summary
+
+Organizations evaluating enterprise data platforms in 2026 face a market with four dominant contenders: Microsoft Fabric, Databricks, Snowflake, and Azure Synapse Analytics. Each platform has matured significantly, but they approach the problem from fundamentally different architectural philosophies. Fabric unifies compute, storage, governance, and BI into a single SaaS experience anchored on OneLake. Databricks leads in open-source Spark engineering and MLOps. Snowflake excels at multi-cloud data sharing and governed SQL analytics. Synapse Analytics, while still supported, has been largely superseded by Fabric for new deployments in the Microsoft ecosystem.
+
+This paper provides a structured comparison across ten dimensions — architecture, compute, storage, governance, BI integration, AI/ML capabilities, real-time analytics, cost model, ecosystem maturity, and migration complexity — to help enterprise architects and CDOs make informed platform decisions.
+
+## Comparison Framework
+
+The following framework evaluates each platform across dimensions that matter most to enterprise buyers. Scores are directional assessments, not absolute rankings, and reflect the state of each platform as of early 2026.
+
+```mermaid
+flowchart TD
+    A[Platform Selection] --> B{Primary Workload?}
+    B -->|Unified Analytics + BI| C[Microsoft Fabric]
+    B -->|Advanced ML/MLOps| D[Databricks]
+    B -->|Multi-Cloud SQL Analytics| E[Snowflake]
+    B -->|Legacy Synapse Investment| F[Azure Synapse]
+
+    C --> G{Decision Factors}
+    D --> G
+    E --> G
+    F --> G
+
+    G --> H[Architecture Fit]
+    G --> I[Cost Model]
+    G --> J[Governance Needs]
+    G --> K[Team Skills]
+    G --> L[Migration Effort]
+```
+
+## 1. Architecture Philosophy
+
+Each platform reflects a distinct architectural vision that shapes every downstream decision — from how data is stored to how governance is enforced.
+
+### Microsoft Fabric
+
+Fabric is a unified SaaS analytics platform built on OneLake, a single-copy data lake that underpins all workloads. Every Fabric item — Lakehouse, Warehouse, Eventhouse, Notebook, Pipeline, Semantic Model — reads from and writes to OneLake in Delta Parquet format. This eliminates data duplication across analytics layers and ensures that governance policies (via Microsoft Purview) apply uniformly. The platform uses a shared capacity model where a single Fabric capacity (measured in Capacity Units, or CUs) powers all workloads, with automatic workload balancing and burst/smoothing behavior.
+
+The architectural bet is on convergence: rather than best-of-breed tools stitched together via ETL, Fabric provides a "good enough at everything, excellent at integration" experience. This is most compelling for organizations that are already invested in the Microsoft ecosystem (Azure, Power BI, Microsoft 365, Purview) and want to reduce operational complexity.
+
+### Databricks
+
+Databricks is built on Apache Spark and the Lakehouse architecture, combining the flexibility of data lakes with the reliability of data warehouses. The platform centers on the Unity Catalog for governance, Delta Lake for ACID transactions, and a highly optimized Photon SQL engine for warehouse-style queries. Databricks runs on all three major clouds (Azure, AWS, GCP) and offers the deepest integration with open-source data engineering and ML tools (MLflow, Feature Store, Model Serving).
+
+The architectural bet is on openness and performance: Databricks gives engineering teams maximum control over compute configuration, cluster sizing, and runtime behavior, at the cost of higher operational complexity. Organizations with strong data engineering teams and advanced ML/AI workloads often find Databricks' flexibility worth the overhead.
+
+### Snowflake
+
+Snowflake is a cloud-native data warehouse built on a separation of storage and compute architecture. Each workload runs in its own virtual warehouse (compute cluster), and all data is stored in a proprietary columnar format. Snowflake's differentiators are its zero-management compute scaling, cross-cloud data sharing via Snowflake Marketplace, and its Snowpark developer experience for Python/Java/Scala workloads. The platform has expanded into streaming (Snowpipe Streaming), ML (Snowpark ML, Cortex), and application development (Streamlit, Native Apps).
+
+The architectural bet is on simplicity and portability: Snowflake abstracts away infrastructure management almost entirely and provides the most frictionless multi-cloud experience. Organizations that need governed SQL analytics across AWS, Azure, and GCP without cloud lock-in often gravitate toward Snowflake.
+
+### Azure Synapse Analytics
+
+Synapse Analytics was Microsoft's pre-Fabric attempt to unify SQL pools, Spark pools, and pipeline orchestration in a single Azure service. While still supported and receiving security updates, Synapse has been de-emphasized in favor of Fabric for new workloads. Existing Synapse investments can be migrated to Fabric via workspace migration tools, and the Synapse SQL engine now powers Fabric's Warehouse experience.
+
+The architectural bet was on Azure-native integration, but the multi-service model created friction around data movement, governance, and billing that Fabric's unified architecture resolves.
+
+## 2. Feature Matrix
+
+| Capability | Fabric | Databricks | Snowflake | Synapse |
+|-----------|--------|------------|-----------|---------|
+| **Unified storage** | OneLake (Delta Parquet) | Delta Lake (open) | Proprietary columnar | ADLS Gen2 + SQL pools |
+| **SQL analytics** | Warehouse (T-SQL) | Databricks SQL (ANSI) | Snowflake SQL (ANSI) | Dedicated/Serverless SQL |
+| **Spark processing** | Spark via Notebooks | Optimized Spark + Photon | Snowpark (Spark-like) | Spark pools |
+| **Real-time ingestion** | Eventstream + Eventhouse | Delta Live Tables + Structured Streaming | Snowpipe Streaming | Event Hubs integration |
+| **BI integration** | Direct Lake (native) | Partner BI via JDBC/ODBC | Partner BI via JDBC/ODBC | Power BI via DirectQuery |
+| **Governance** | Purview (built-in) | Unity Catalog | Horizon (governance) | Purview (add-on) |
+| **AI/ML** | AutoML, Copilot, Data Agents, AI Functions | MLflow, Feature Store, Model Serving, Mosaic | Cortex, Snowpark ML | Azure ML integration |
+| **Data sharing** | Shortcuts, Mirroring | Delta Sharing (open protocol) | Snowflake Marketplace | Linked services |
+| **Multi-cloud** | Azure only | Azure, AWS, GCP | Azure, AWS, GCP | Azure only |
+| **CI/CD** | fabric-cicd, Git integration | Databricks Asset Bundles, Repos | Schemachange, Terraform | ARM/Bicep, Synapse Git |
+| **Cost model** | Capacity Units (CU) — shared pool | DBU — per-cluster billing | Credits — per-warehouse billing | DWU + vCore — per-pool billing |
+| **Iceberg support** | Read via shortcuts + mirroring | Read/write via UniForm | Native Iceberg tables | Limited |
+| **Digital twin** | Digital Twin Builder (preview) | Partner solutions | Not available | Not available |
+| **Copilot/AI assist** | Fabric Copilot (native) | Databricks Assistant | Snowflake Cortex | Limited |
+
+## 3. Total Cost of Ownership Analysis
+
+TCO comparisons between platforms are notoriously difficult because pricing models differ fundamentally. The following framework normalizes cost into categories that apply across all four platforms.
+
+### Cost Categories
+
+**Compute costs** represent the largest portion of TCO for all platforms. Fabric uses a shared CU pool where all workloads draw from the same capacity, which can lead to efficient utilization but also contention. Databricks bills per DBU per cluster, giving precise cost attribution but requiring active cluster management. Snowflake bills per credit per virtual warehouse, with automatic suspend/resume reducing idle costs. Synapse bills per DWU for dedicated pools and per query for serverless.
+
+**Storage costs** are relatively similar across platforms when using cloud-native object storage (ADLS, S3, GCS). Fabric's OneLake eliminates duplication costs by storing data once. Snowflake's proprietary storage adds a small premium. Databricks and Synapse use open formats on cloud storage.
+
+**Governance and security costs** are often hidden. Fabric includes Purview integration at no additional cost. Databricks Unity Catalog is included in Premium/Enterprise tiers. Snowflake Horizon is included. Synapse requires separate Purview licensing.
+
+**Operational costs** — the human effort to manage, monitor, and troubleshoot the platform — vary significantly. Fabric and Snowflake minimize operational overhead through SaaS automation. Databricks requires more engineering effort for cluster management, job scheduling, and cost optimization. Synapse sits in between.
+
+### Normalized TCO Comparison (Illustrative)
+
+| Cost Component | Fabric (F64) | Databricks (Premium) | Snowflake (Enterprise) | Synapse (Dedicated) |
+|---------------|-------------|---------------------|----------------------|-------------------|
+| Compute (annual) | ~$105K (F64 PAYG) | ~$120-180K (varies by cluster) | ~$100-160K (varies by warehouse) | ~$90-150K (varies by DWU) |
+| Storage (10 TB) | ~$2.4K (ADLS rates) | ~$2.4K (ADLS/S3 rates) | ~$4.6K (Snowflake storage) | ~$2.4K (ADLS rates) |
+| Governance | Included (Purview) | Included (Unity Catalog) | Included (Horizon) | +$12-24K (Purview) |
+| BI tooling | Included (Power BI) | +$12-120K (Tableau/Power BI) | +$12-120K (Tableau/Power BI) | +$12-120K (Power BI Pro/Premium) |
+| Ops FTE (partial) | 0.25-0.5 FTE | 0.5-1.0 FTE | 0.25-0.5 FTE | 0.5-0.75 FTE |
+| **Estimated 3-yr TCO** | **$350-450K** | **$500-700K** | **$400-600K** | **$400-550K** |
+
+These estimates are illustrative for a mid-size analytics workload (50 users, 10 TB, moderate Spark, daily BI refresh). Actual costs vary significantly by workload profile, negotiated pricing, and operational maturity.
+
+### When Fabric Wins on Cost
+
+Fabric's cost advantage is strongest when an organization already has Microsoft 365 E5 licensing (which includes Power BI Pro), uses Azure as its primary cloud, and can consolidate multiple analytics workloads onto a single Fabric capacity. The shared CU pool means that interactive BI queries, batch Spark jobs, and real-time streaming all draw from the same budget, avoiding the per-service billing silos that inflate costs on other platforms.
+
+### When Fabric Loses on Cost
+
+Fabric's cost advantage diminishes for organizations that run heavy, sustained Spark workloads (where Databricks' Photon engine delivers better price/performance), need multi-cloud deployment (where Snowflake's portability avoids cloud lock-in premiums), or have existing Databricks/Snowflake investments that would require costly migration to abandon.
+
+## 4. Maturity Assessment
+
+Platform maturity spans technical capability, ecosystem breadth, community size, and enterprise adoption. The following assessment uses a five-level maturity model.
+
+| Dimension | Fabric | Databricks | Snowflake | Synapse |
+|-----------|--------|------------|-----------|---------|
+| SQL analytics | Level 4 (Mature) | Level 4 (Mature) | Level 5 (Leader) | Level 4 (Mature) |
+| Spark/data engineering | Level 3 (Established) | Level 5 (Leader) | Level 3 (Established) | Level 3 (Established) |
+| Real-time streaming | Level 3 (Established) | Level 4 (Mature) | Level 2 (Developing) | Level 2 (Developing) |
+| BI integration | Level 5 (Leader) | Level 2 (Developing) | Level 3 (Established) | Level 3 (Established) |
+| AI/ML | Level 3 (Established) | Level 5 (Leader) | Level 3 (Established) | Level 2 (Developing) |
+| Governance | Level 4 (Mature) | Level 4 (Mature) | Level 4 (Mature) | Level 3 (Established) |
+| Multi-cloud | Level 1 (Azure only) | Level 5 (Leader) | Level 5 (Leader) | Level 1 (Azure only) |
+| Enterprise adoption | Level 3 (Growing fast) | Level 5 (Dominant) | Level 5 (Dominant) | Level 4 (Established) |
+| Community/ecosystem | Level 3 (Growing) | Level 5 (Massive) | Level 4 (Large) | Level 3 (Stable) |
+| Operational simplicity | Level 4 (SaaS) | Level 2 (Complex) | Level 5 (Simplest) | Level 2 (Complex) |
+
+### Maturity Levels Defined
+
+- **Level 1 — Nascent:** Capability exists but is early, limited, or requires significant workarounds.
+- **Level 2 — Developing:** Functional for basic scenarios but missing enterprise features, community support, or partner integrations.
+- **Level 3 — Established:** Production-ready for most enterprise scenarios with active development, growing community, and solid documentation.
+- **Level 4 — Mature:** Feature-rich, well-documented, widely adopted, with strong partner ecosystem and proven at scale.
+- **Level 5 — Leader:** Market-defining capability that sets the standard for the category, with dominant market share, deep ecosystem, and continuous innovation.
+
+## 5. Migration Considerations
+
+### Migrating to Fabric
+
+Organizations migrating to Fabric typically come from one of four starting points:
+
+**From Synapse Analytics:** The most straightforward migration path. Fabric's Warehouse uses the same T-SQL engine as Synapse dedicated pools. Pipelines migrate with minimal changes. Spark notebooks require replacing `%%configure` with Fabric's Spark session configuration. Microsoft provides workspace migration tooling. See the [migration patterns](../best-practices/migration-patterns.md) guide.
+
+**From Databricks:** Requires rewriting Spark notebooks to replace Databricks-specific APIs (dbutils, Databricks widgets, Unity Catalog references) with Fabric equivalents (mssparkutils, Fabric notebook parameters, Purview). Delta Lake tables can be accessed via OneLake shortcuts without data movement. MLflow models need to be re-registered in Fabric's ML model registry.
+
+**From Snowflake:** Requires the most architectural change since Snowflake's proprietary storage format doesn't directly translate to Delta Parquet. Data must be exported and re-ingested. SQL stored procedures need rewriting from Snowflake's JavaScript UDFs to Fabric's T-SQL or Spark equivalents. Snowpipe integrations need replacement with Fabric Eventstreams or Pipelines.
+
+**From on-premises (SQL Server, Oracle, Teradata):** Fabric provides Mirroring for near-real-time replication from SQL Server and Azure SQL Database. For other sources, use Data Factory pipelines with on-premises data gateway. The [migration tutorial](../tutorials/10_migration_teradata_fabric.md) covers Teradata-specific patterns.
+
+### Migration Risk Assessment
+
+| Risk Factor | Low Risk | Medium Risk | High Risk |
+|------------|----------|-------------|-----------|
+| Data volume | < 1 TB | 1-50 TB | > 50 TB |
+| Custom code | < 50 notebooks/queries | 50-200 | > 200 |
+| Real-time integrations | None | 1-5 streams | > 5 streams |
+| Governance policies | Basic RBAC | Column-level security | Row-level + dynamic masking |
+| External dependencies | Cloud-native APIs | On-prem gateways | Mainframe/legacy systems |
+| Team familiarity | Microsoft stack | Mixed cloud experience | No Microsoft experience |
+
+## 6. Decision Guidance
+
+### Choose Fabric When
+
+- Your organization is already invested in the Microsoft ecosystem (Azure, Microsoft 365, Power BI)
+- You want a single platform for data engineering, analytics, BI, and governance
+- Operational simplicity is a priority over maximum configurability
+- Power BI Direct Lake performance matters for your BI workload
+- You need integrated real-time analytics with minimal infrastructure management
+- Budget consolidation across analytics services is a goal
+
+### Choose Databricks When
+
+- You have a strong data engineering team comfortable with Spark and cluster management
+- Advanced ML/MLOps workloads (model training, feature stores, model serving) are central to your strategy
+- You need multi-cloud deployment flexibility
+- Open-source alignment and community-driven innovation are important
+- You need maximum control over compute performance tuning
+- Your organization has existing Databricks investments and expertise
+
+### Choose Snowflake When
+
+- Multi-cloud data sharing (across AWS, Azure, GCP) is a hard requirement
+- You need the simplest possible operational model for SQL analytics
+- Data marketplace and governed data sharing are core to your strategy
+- Your workload is predominantly SQL-based with modest Spark requirements
+- You prioritize cross-cloud portability over deep ecosystem integration with any single cloud
+- Your BI strategy is multi-vendor (not exclusively Power BI)
+
+### Choose Synapse When
+
+- You have significant existing Synapse investments that don't justify migration cost
+- Your workloads are stable and don't require new Fabric capabilities
+- You are planning a phased migration to Fabric and need to run both platforms in parallel
+- Specific Synapse features (dedicated SQL pool partitioning, Synapse Link for Cosmos DB) are critical and don't yet have Fabric equivalents
+
+## 7. Architecture Comparison
+
+```mermaid
+flowchart LR
+    subgraph Fabric["Microsoft Fabric"]
+        direction TB
+        OL[OneLake] --> LH[Lakehouse]
+        OL --> WH[Warehouse]
+        OL --> EH[Eventhouse]
+        LH --> DL[Direct Lake]
+        DL --> PBI[Power BI]
+        OL --> PV[Purview Governance]
+    end
+
+    subgraph DBX["Databricks"]
+        direction TB
+        DLK[Delta Lake] --> SP[Spark Clusters]
+        DLK --> DBSQL[Databricks SQL]
+        SP --> MLF[MLflow]
+        DLK --> UC[Unity Catalog]
+    end
+
+    subgraph SF["Snowflake"]
+        direction TB
+        SS[Snowflake Storage] --> VW[Virtual Warehouses]
+        SS --> SPK[Snowpark]
+        VW --> MKT[Marketplace]
+        SS --> HZ[Horizon]
+    end
+```
+
+## 8. Real-Time Analytics Comparison
+
+Real-time analytics has become a critical differentiator as organizations move from batch-only to streaming-first architectures. Each platform approaches real-time data differently.
+
+**Fabric** provides a fully integrated real-time pipeline: Eventstream ingests data from Azure Event Hubs, Kafka, and custom sources; Eventhouse (powered by Azure Data Explorer / KQL engine) provides sub-second query performance on streaming data; Real-Time Dashboards render live visualizations; and Data Activator triggers automated actions based on conditions in the stream. The advantage is tight integration — from ingestion to alerting in a single platform. The limitation is that Eventstream throughput is bounded by the Fabric capacity SKU.
+
+**Databricks** offers Structured Streaming and Delta Live Tables for stream processing within the Spark ecosystem. DLT provides declarative pipeline definitions with automatic data quality enforcement (expectations). Databricks excels at complex stream processing logic but requires separate infrastructure for dashboarding (typically pushing to a partner BI tool) and alerting (typically through third-party monitoring).
+
+**Snowflake** introduced Snowpipe Streaming for low-latency data loading and Dynamic Tables for incremental materialization. While improving rapidly, Snowflake's streaming capabilities are less mature than Fabric's Eventhouse or Databricks' Structured Streaming for complex event processing. Snowflake's strength is simplifying the transition from batch to near-real-time without requiring new skill sets.
+
+**Synapse** offers Event Hubs integration and Spark Structured Streaming via Spark pools, but lacks the integrated real-time dashboard and alerting capabilities that Fabric provides natively.
+
+| Capability | Fabric | Databricks | Snowflake | Synapse |
+|-----------|--------|------------|-----------|---------|
+| Stream ingestion | Eventstream (native) | Structured Streaming | Snowpipe Streaming | Event Hubs + Spark |
+| Stream processing | Eventhouse (KQL) | Delta Live Tables | Dynamic Tables | Spark pools |
+| Sub-second query | Yes (KQL engine) | Yes (Photon) | Limited | No |
+| Real-time dashboards | Built-in | Partner BI tools | Partner BI tools | Partner BI tools |
+| Automated alerts | Data Activator | Third-party | Third-party | Azure Monitor |
+| Complex event processing | KQL time-series functions | Spark windowing | Limited | Spark windowing |
+
+## 9. Ecosystem and Community
+
+The surrounding ecosystem — community size, partner integrations, educational resources, and marketplace offerings — significantly impacts long-term platform viability and talent availability.
+
+**Databricks** has the largest and most active open-source community, driven by its stewardship of Apache Spark, Delta Lake, MLflow, and Unity Catalog. The Databricks Community Edition provides free access for learning. Partner integrations span hundreds of tools across data ingestion, BI, ML, and governance. Talent availability is strong, particularly among data engineers with Spark experience.
+
+**Snowflake** has built a massive commercial ecosystem around Snowflake Marketplace, Snowflake Native Apps, and a large partner network. The Snowflake community is heavily SQL-oriented, which makes it accessible to a broad talent pool. Snowflake's annual Summit conference and active user groups drive community engagement.
+
+**Fabric** has the fastest-growing community, driven by Microsoft's investment in Fabric Community forums, Microsoft Learn training paths, and the existing Power BI community (one of the largest BI communities globally). However, the Fabric-specific ecosystem is still maturing relative to Databricks and Snowflake, particularly for third-party tool integrations. Talent availability is growing rapidly as existing Microsoft data professionals upskill to Fabric.
+
+**Synapse** has a stable but declining community as Microsoft shifts investment to Fabric. Existing Synapse practitioners are migrating their skills to Fabric, and new entrants are choosing Fabric directly.
+
+## 10. Conclusion
+
+There is no universally "best" enterprise data platform — the right choice depends on your organization's existing investments, team skills, workload profile, multi-cloud requirements, and strategic priorities. Fabric offers the most compelling value for Microsoft-ecosystem organizations that want unified analytics with minimal operational overhead. Databricks leads for engineering-heavy organizations with advanced ML requirements. Snowflake excels for multi-cloud SQL analytics with maximum simplicity. Synapse remains viable for existing investments but is not recommended for greenfield deployments.
+
+The most pragmatic approach for many enterprises is a hybrid strategy: use Fabric for the integrated analytics-to-BI pipeline, supplement with Databricks or Snowflake for specialized workloads that benefit from their unique strengths, and connect them via open formats (Delta Lake, Iceberg) and standard protocols (JDBC/ODBC, Delta Sharing).
+
+## Related Documentation
+
+- [Direct Lake](../features/direct-lake.md) — Fabric's native Power BI connectivity mode
+- [Mirroring](../features/mirroring.md) — Real-time database replication into OneLake
+- [Migration Patterns](../best-practices/migration-patterns.md) — Enterprise migration strategies
+- [Capacity Planning & Cost Optimization](../best-practices/capacity-planning-cost-optimization.md) — Fabric CU budgeting
+- [Fabric vs Databricks vs Synapse Decision Tree](../decisions/fabric-databricks-synapse.md) — Interactive decision flowchart

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,0 +1,42 @@
+# Research & White Papers
+
+Strategic analysis, maturity frameworks, and platform comparisons to guide enterprise Fabric adoption decisions.
+
+<div class="grid cards" markdown>
+
+-   :material-scale-balance:{ .lg .middle } __Enterprise Data Platform Comparison__
+
+    ---
+
+    Fabric vs Databricks vs Snowflake vs Synapse — feature matrix, TCO analysis, and migration guidance for 2026.
+
+    [:octicons-arrow-right-24: Read comparison](enterprise-data-platform-comparison.md)
+
+-   :material-robot-outline:{ .lg .middle } __AI Readiness Assessment__
+
+    ---
+
+    Evaluate your organization's readiness to adopt Fabric AI capabilities — Copilot, AutoML, Semantic Link, Data Agents, and AI Functions.
+
+    [:octicons-arrow-right-24: Assess readiness](ai-readiness-assessment.md)
+
+-   :material-hexagon-multiple-outline:{ .lg .middle } __Data Mesh Maturity Model__
+
+    ---
+
+    Implement Data Mesh principles on Fabric — workspaces as domains, OneLake as federated storage, Purview as governance plane.
+
+    [:octicons-arrow-right-24: Explore maturity model](data-mesh-maturity-model.md)
+
+</div>
+
+## How to Use These Papers
+
+These research documents provide analytical depth beyond feature documentation. Use them to:
+
+- **Build a business case** for Fabric adoption with TCO comparisons and feature matrices
+- **Assess organizational readiness** before investing in AI capabilities
+- **Plan architecture evolution** from centralized analytics to a federated data mesh
+- **Communicate strategy** to executive stakeholders with visual frameworks and maturity models
+
+Each paper includes Mermaid diagrams, comparison tables, and cross-references to the detailed feature and best-practice documentation elsewhere in this site.


### PR DESCRIPTION
## Summary
- Enterprise Data Platform Comparison 2026 — Fabric vs Databricks vs Snowflake vs Synapse (3,262 words)
- AI Readiness Assessment — maturity model, assessment questionnaire, implementation roadmap (3,060 words)
- Data Mesh Maturity Model — migration path from centralized to mesh on Fabric (3,548 words)
- Section index page with Material grid cards

## Test plan
- [ ] Verify 4 files exist in `docs/research/`
- [ ] Each paper exceeds 3,000 words
- [ ] Each paper includes at least one Mermaid diagram
- [ ] Each paper includes comparison or assessment tables
- [ ] Links reference existing feature and best-practice docs
- [ ] `mkdocs build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)