### PR TITLE
fix(tutorial-57): pyarrow nanosecond timestamps break Spark/Delta ingest

### DIFF
--- a/tutorials/57-databricks-better-together/notebooks/setup/01_load_sample_data.py
+++ b/tutorials/57-databricks-better-together/notebooks/setup/01_load_sample_data.py
@@ -60,14 +60,34 @@ print(f"Files present: {sorted(available)}")
 
 # MAGIC %md
 # MAGIC ## 2. Load each parquet into Delta in `retail_raw`
+# MAGIC
+# MAGIC PyArrow writes nanosecond timestamps by default, which Spark/Delta
+# MAGIC cannot ingest (`Illegal Parquet type: INT64 (TIMESTAMP(NANOS,false))`).
+# MAGIC The generator script now coerces to microseconds at write time, but we
+# MAGIC keep a defensive read-side cast here so older parquet drops still load.
 
 # COMMAND ----------
+
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 for table in TABLES:
     source = f"{LANDING_PATH}/retail/{table}.parquet"
     target = f"{CATALOG_NAME}.{RAW_SCHEMA}.{table}"
 
-    df = spark.read.parquet(source)
+    arrow_tbl = pq.read_table(source)
+    new_fields = []
+    needs_cast = False
+    for fld in arrow_tbl.schema:
+        if pa.types.is_timestamp(fld.type) and fld.type.unit == "ns":
+            new_fields.append(fld.with_type(pa.timestamp("us")))
+            needs_cast = True
+        else:
+            new_fields.append(fld)
+    if needs_cast:
+        arrow_tbl = arrow_tbl.cast(pa.schema(new_fields))
+
+    df = spark.createDataFrame(arrow_tbl.to_pandas())
     df.write.format("delta").mode("overwrite").saveAsTable(target)
 
     count = spark.table(target).count()

--- a/tutorials/57-databricks-better-together/scripts/generate_sample_data.py
+++ b/tutorials/57-databricks-better-together/scripts/generate_sample_data.py
@@ -51,7 +51,16 @@ def main(output_root: Path, seed: int) -> None:
     retail = BetterTogetherRetailGenerator(seed=seed).generate_all()
     for name, df in retail.items():
         path = retail_root / f"{name}.parquet"
-        df.to_parquet(path, engine="pyarrow", index=False)
+        # coerce_timestamps='us' is required for Spark/Delta — Spark cannot
+        # ingest the nanosecond timestamps that pyarrow writes by default
+        # (Illegal Parquet type: INT64 (TIMESTAMP(NANOS,false))).
+        df.to_parquet(
+            path,
+            engine="pyarrow",
+            index=False,
+            coerce_timestamps="us",
+            allow_truncated_timestamps=True,
+        )
         print(f"  - {name:<14} {len(df):>7,} rows  -> {path.name}")
 
     print(f"[Tutorial 57] Writing persona seed data to {persona_root}")


### PR DESCRIPTION
## Summary

Hit during the first live walk-through of tutorial 57 on the deployed FedCiv DLZ Databricks workspace: cell 8 (Delta writes) failed with:

> \`Illegal Parquet type: INT64 (TIMESTAMP(NANOS,false))\`

PyArrow writes nanosecond timestamps by default; Spark/Delta only support millis/micros. Two complementary fixes:

- **\`generate_sample_data.py\`** — pass \`coerce_timestamps='us'\` + \`allow_truncated_timestamps=True\` so fresh parquet output is Spark-ingestible at the source.
- **\`01_load_sample_data.py\`** — defensive read-side cast via pyarrow (\`pa.timestamp('us')\`) so older parquet drops still load on upgrade.

## Validation

Verified end-to-end against the live tut57-uc-cluster:
- 5 Delta tables created in \`better_together.retail_raw\`: customers (500), products (120), orders (2,018), order_lines (5,247), returns (42)
- 2 dynamic views in \`better_together.retail_secure\`: \`orders_by_region\`, \`audit_revenue_summary\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)