### PR TITLE
fix(ci): stop deploy-infra failing + auto-filing issues on every push to main

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -46,13 +46,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Login to Azure
-        uses: azure/login@v3
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
+      # NOTE: `az bicep build`/`lint` are purely local compilation — they need
+      # no Azure authentication. (Previously this job ran `azure/login`, which
+      # made every push to main fail at login when the AZURE_* OIDC secrets are
+      # not configured, and spammed a "Deployment Failed" issue each time.)
       - name: Build Bicep
         run: |
           az bicep build --file infra/main.bicep
@@ -67,6 +64,11 @@ jobs:
     name: What-If Analysis
     runs-on: ubuntu-latest
     needs: validate
+    # Deployment requires Azure OIDC credentials (AZURE_CLIENT_ID / TENANT_ID /
+    # SUBSCRIPTION_ID). Until those are configured, run the deploy chain only on
+    # explicit manual dispatch — push to main just validates Bicep. This keeps
+    # main green and stops the auto-filed "Deployment Failed" issues.
+    if: github.event_name == 'workflow_dispatch'
     environment: ${{ inputs.environment || 'dev' }}
     outputs:
       changes: ${{ steps.whatif.outputs.changes }}
@@ -113,7 +115,7 @@ jobs:
     name: Deploy to ${{ inputs.environment || 'dev' }}
     runs-on: ubuntu-latest
     needs: what-if
-    if: needs.what-if.outputs.changes == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     environment:
       name: ${{ inputs.environment || 'dev' }}
       url: https://portal.azure.com
@@ -189,7 +191,9 @@ jobs:
     name: Notify on Failure
     runs-on: ubuntu-latest
     needs: [validate, what-if, deploy, smoke-test]
-    if: failure()
+    # Only raise a tracking issue for real (manual) deployment failures — never
+    # for push-triggered validation runs.
+    if: failure() && github.event_name == 'workflow_dispatch'
     steps:
       - name: Create Issue on Failure
         uses: actions/github-script@v9


### PR DESCRIPTION
## Problem

The **Deploy Infrastructure** workflow has failed on **every push to main** for months (Apr 28, May 20, May 28…) and auto-files a `Deployment Failed` issue each time — most recently **#92** when PR #91 merged.

Root cause (from run [26598479943](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/actions/runs/26598479943)):
> `Login failed … Ensure 'client-id' and 'tenant-id' are supplied`

Two issues:
1. The **Validate Bicep** job runs `azure/login` before `az bicep build` — but `bicep build`/`lint` are **local** and need no Azure auth. With no `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` OIDC secrets configured, login fails immediately on every push.
2. The `push` trigger runs the whole deploy chain (what-if → deploy → smoke-test), none of which can succeed without those secrets, and `notify` opens an issue on each failure.

## Fix

- **Remove `azure/login` from the validate job** → push-to-main now validates Bicep with no credentials.
- **Gate `what-if` / `deploy` / `notify` to `workflow_dispatch` only** → deployment is an explicit manual action; push to main only validates.
- **`notify` only files an issue for real (manual) deploy failures.**

No Bicep or template changes. When OIDC secrets are added later, relax the `if:` guards to re-enable push-triggered deploy.

## Validation
- `yaml.safe_load` parses clean; jobs intact (`validate`, `what-if`, `deploy`, `smoke-test`, `notify`).
- `validate` steps now: Checkout → Build Bicep → Lint Bicep (no login).
- `what-if` / `deploy` / `notify` guarded to `github.event_name == 'workflow_dispatch'`.

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)