### PR TITLE
docs(tutorial-57): link notebook pages to their .py source on GitHub

### DIFF
--- a/notebooks/hitchhikers-guide/README.md
+++ b/notebooks/hitchhikers-guide/README.md
@@ -13,15 +13,19 @@ Seven independently-runnable notebooks that you can import into any Fabric
 workspace and use as a runtime reference. They are **not** a tutorial — each
 file is a flat list of recipes you can copy/paste into a real notebook.
 
+> 📓 **The notebook links below open the `.py` source on GitHub** (the docs
+> site renders this guide page, not the notebook files themselves). Download
+> or copy any notebook, then import it into your Fabric workspace.
+
 | # | Notebook | Audience | When to open it |
 |---|---|---|---|
-| 00 | `00_guide_index.py` | Everyone | First time — read the conventions |
-| 01 | `01_guide_connectivity.py` | Data engineers, integration leads | "How do I connect Fabric to ___ ?" |
-| 02 | `02_guide_lakehouse_warehouse_ops.py` | Data engineers | Delta, MERGE, OPTIMIZE, schemas, partitioning |
-| 03 | `03_guide_security_identity.py` | Security engineers | RLS, CLS, DDM, tokens, MSAL, Key Vault |
-| 04 | `04_guide_admin_governance.py` | Platform admins | REST APIs for workspaces, lakehouses, Git, deployment pipelines |
-| 05 | `05_guide_automation_utilities.py` | Automation engineers | `notebookutils` everything, DAG runs, parameters |
-| 06 | `06_guide_troubleshooting.py` | Everyone (eventually) | Symptom → cause → fix table |
+| 00 | [`00_guide_index.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/notebooks/hitchhikers-guide/00_guide_index.py) | Everyone | First time — read the conventions |
+| 01 | [`01_guide_connectivity.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/notebooks/hitchhikers-guide/01_guide_connectivity.py) | Data engineers, integration leads | "How do I connect Fabric to ___ ?" |
+| 02 | [`02_guide_lakehouse_warehouse_ops.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/notebooks/hitchhikers-guide/02_guide_lakehouse_warehouse_ops.py) | Data engineers | Delta, MERGE, OPTIMIZE, schemas, partitioning |
+| 03 | [`03_guide_security_identity.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/notebooks/hitchhikers-guide/03_guide_security_identity.py) | Security engineers | RLS, CLS, DDM, tokens, MSAL, Key Vault |
+| 04 | [`04_guide_admin_governance.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/notebooks/hitchhikers-guide/04_guide_admin_governance.py) | Platform admins | REST APIs for workspaces, lakehouses, Git, deployment pipelines |
+| 05 | [`05_guide_automation_utilities.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/notebooks/hitchhikers-guide/05_guide_automation_utilities.py) | Automation engineers | `notebookutils` everything, DAG runs, parameters |
+| 06 | [`06_guide_troubleshooting.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/notebooks/hitchhikers-guide/06_guide_troubleshooting.py) | Everyone (eventually) | Symptom → cause → fix table |
 
 ## Why "Hitchhiker's Guide"?
 

--- a/tutorials/57-databricks-better-together/README.md
+++ b/tutorials/57-databricks-better-together/README.md
@@ -313,3 +313,20 @@ Companion files outside this directory:
 - `data_generation/generators/better_together/` — sample-data generators
 - `infra/modules/databricks/databricks-workspace.bicep` — DBW module
 - `infra/modules/security/key-vault.bicep` — Key Vault module
+
+## 📓 Open the notebooks
+
+> The docs site renders this page, not the `.py` notebooks. The links below
+> open each notebook's source on GitHub — download/copy it, then import into
+> your workspace (Databricks for setup, Fabric for mirroring/gold/security).
+
+| Notebook | Runs in | Purpose |
+|---|---|---|
+| [`setup/00_create_unity_catalog.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/tutorials/57-databricks-better-together/notebooks/setup/00_create_unity_catalog.py) | Databricks | UC catalog + schemas + volume |
+| [`setup/01_load_sample_data.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/tutorials/57-databricks-better-together/notebooks/setup/01_load_sample_data.py) | Databricks | Load 5 Delta tables + secure views |
+| [`mirroring/01_register_full_catalog_mirror.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/tutorials/57-databricks-better-together/notebooks/mirroring/01_register_full_catalog_mirror.py) | Fabric | Full catalog mirror (REST) |
+| [`mirroring/02_register_partial_mirror.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/tutorials/57-databricks-better-together/notebooks/mirroring/02_register_partial_mirror.py) | Fabric | Inclusion + exclusion-list mirrors |
+| [`mirroring/03_query_mirror_from_spark.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/tutorials/57-databricks-better-together/notebooks/mirroring/03_query_mirror_from_spark.py) | Fabric | Read the mirror (Spark / T-SQL / sempy) |
+| [`mirroring/04_compare_mirror_vs_shortcut_vs_iceberg.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/tutorials/57-databricks-better-together/notebooks/mirroring/04_compare_mirror_vs_shortcut_vs_iceberg.py) | Fabric | Decision matrix |
+| [`gold/01_gold_star_schema.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/tutorials/57-databricks-better-together/notebooks/gold/01_gold_star_schema.py) | Fabric | Direct-Lake star schema from the mirror |
+| [`security/01_apply_defense_in_depth.py`](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/tutorials/57-databricks-better-together/notebooks/security/01_apply_defense_in_depth.py) | Fabric | Entra groups, OneLake RLS/CLS, Warehouse RLS/DDM |


### PR DESCRIPTION
## Why

The Pages site renders only `README.md` files (the `docs.yml` copy step pulls in READMEs, not the `.py` notebooks). So on the published **Hitchhiker's Guide** and **Tutorial 57** pages, the notebook filenames were plain text — readers had no way to reach the actual notebooks.

## What

- **Hitchhiker's Guide README** — each of the 7 notebooks now links to its GitHub blob URL, with a one-line note explaining the docs-vs-notebook distinction.
- **Tutorial 57 README** — added an "📓 Open the notebooks" table linking all 8 setup/mirroring/gold/security notebooks to GitHub source, tagged Databricks vs Fabric.

All linked paths verified present on `main`.

## Verified
- New pages already return **HTTP 200** on the live site (tutorial 57, TEST_PLAN, semantic-model, hitchhikers, defense-in-depth) — no 404/401.
- This PR makes the notebook references clickable once Pages rebuilds on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)