### PR TITLE
fix(ci): rebuild docs when notebook README.md files change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ on:
       - 'docs/**'
       - 'tutorials/**'
       - 'poc-agenda/**'
+      # notebook README.md files are copied into the site at build time, so a
+      # change to any of them must rebuild the docs (previously omitted — so
+      # notebook-guide edits never published).
+      - 'notebooks/**/README.md'
       - 'infra/README.md'
       - 'mkdocs.yml'
       - 'README.md'


### PR DESCRIPTION
`docs.yml` copies `notebooks/**/README.md` into the site at build time, but `notebooks/**` was **not** in the push `paths` filter — so editing any notebook-guide page never triggered a Pages rebuild. That's why PR #96's notebook links didn't go live.

**Fix:** add `notebooks/**/README.md` to the trigger paths. Merging this also rebuilds the site (it touches `docs.yml`), publishing #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)