### PR TITLE
fix(docs): correct branding, add personal-project disclaimers, tighten claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ![Tests](https://img.shields.io/badge/Tests-612_Passing-brightgreen?style=for-the-badge)
 ![Phase](https://img.shields.io/badge/Phase_11-Complete-brightgreen?style=for-the-badge)
 
-**Transform your casino operations with enterprise-grade analytics powered by Microsoft Fabric**
+**A hands-on Microsoft Fabric reference for data teams in regulated industries** — it starts in casino & gaming, bridges through Tribal Nations gaming and health, and extends out to federal agency analytics, all on the same medallion + governance backbone.
 
 *Real-time insights • Medallion Architecture • Regulatory Compliance • Direct Lake BI*
 
@@ -29,6 +29,9 @@
 ---
 
 </div>
+
+> [!IMPORTANT]
+> **Personal project — not an official Microsoft product.** This is a personal, community-built reference maintained by [Frank Garofalo](https://github.com/fgarofalo56). It is **not** a sanctioned Microsoft deliverable or official Microsoft Fabric documentation, and the opinions here are the author's own. The compliance pages (FedRAMP, HIPAA, NIST 800-53, NIGC MICS, Title 31/BSA, etc.) are **reference control mappings for education and POC scoping — not authorizations, attestations, or certifications.**
 
 ## 📍 Navigation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -484,5 +484,5 @@ Direct Lake is the recommended connectivity mode for Power BI in Fabric. It prov
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -748,5 +748,5 @@ df.write \
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/docs/COST_ESTIMATION.md
+++ b/docs/COST_ESTIMATION.md
@@ -522,5 +522,5 @@ tags: {
 
 ---
 
-> **Documentation maintained by:** Microsoft Fabric POC Team
+> **Documentation maintained by:** Frank Garofalo
 > **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -894,5 +894,5 @@ After successful deployment, proceed with these guides:
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -455,5 +455,5 @@ FOLLOW-UP: [Actions]
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1832,6 +1832,6 @@ az group delete --name "rg-fabric-poc-dev" --yes
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)
 > 🔄 **Last Updated:** 2025-01-21

--- a/docs/MIGRATION_AND_RTI_RESEARCH.md
+++ b/docs/MIGRATION_AND_RTI_RESEARCH.md
@@ -1027,5 +1027,5 @@ Fabric provides multiple mechanisms for handling late-arriving events:
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/docs/PREREQUISITES.md
+++ b/docs/PREREQUISITES.md
@@ -581,5 +581,5 @@ After completing prerequisites:
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -213,7 +213,7 @@ You should see rows with columns like `machine_id`, `casino_id`, `event_type`, `
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)
 
 **Total Time:** ~15 minutes (mostly waiting for Bicep deployment and Spark cold start).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -832,5 +832,5 @@ flowchart LR
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/docs/best-practices/data-modeling-star-schema.md
+++ b/docs/best-practices/data-modeling-star-schema.md
@@ -815,7 +815,7 @@ df_dim_agency.write.format("delta").mode("overwrite").saveAsTable("lh_gold.dim_a
 |-------|-------|
 | **Title** | Data Modeling & Star Schema Best Practices |
 | **Category** | Best Practices — Data Modeling |
-| **Author** | Supercharge Microsoft Fabric POC Team |
+| **Author** | Frank Garofalo |
 | **Version** | 1.0.0 |
 | **Created** | 2026-04-21 |
 | **Last Updated** | 2026-04-21 |

--- a/docs/best-practices/finops-cost-governance.md
+++ b/docs/best-practices/finops-cost-governance.md
@@ -666,7 +666,7 @@ def federal_cost_report(capacity_cost: float, ws_cu: dict) -> list[dict]:
 |-------|-------|
 | **Title** | FinOps & Cost Governance for Microsoft Fabric |
 | **Category** | Best Practices — Cost Governance |
-| **Author** | Supercharge Microsoft Fabric POC Team |
+| **Author** | Frank Garofalo |
 | **Version** | 1.0.0 |
 | **Created** | 2026-04-21 |
 | **Last Updated** | 2026-04-21 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Home
-description: Supercharge Microsoft Fabric — Casino & Gaming Industry POC with Federal Agency Domains
+description: A personal, hands-on Microsoft Fabric reference for regulated industries — from casino & gaming through Tribal Nations to federal agency analytics. Not an official Microsoft product.
 hide:
   - navigation
   - toc
@@ -9,9 +9,12 @@ hero_alt: "Supercharge Microsoft Fabric — Casino & gaming POC + federal expans
 ---
 # Supercharge Microsoft Fabric
 
-**Transform your operations with enterprise-grade analytics powered by Microsoft Fabric**
+**A hands-on Microsoft Fabric reference for data teams in regulated industries — it starts in casino & gaming, bridges through Tribal Nations gaming and health, and extends out to federal agency analytics.** Same medallion + governance backbone, applied across each domain.
 
 *Real-time insights · Medallion Architecture · Regulatory Compliance · Direct Lake BI*
+
+!!! info "Personal project — not an official Microsoft product"
+    This is a personal, community-built reference maintained by [Frank Garofalo](https://github.com/fgarofalo56). It is **not** a sanctioned Microsoft deliverable, nor official Microsoft Fabric product documentation, and opinions here are the author's own. The compliance pages (FedRAMP, HIPAA, NIST 800-53, NIGC MICS, Title 31/BSA, etc.) are **reference control mappings for education and POC scoping — not authorizations, attestations, or certifications.**
 
 [Quick Start](PREREQUISITES.md){ .md-button .md-button--primary }
 [Tutorials](tutorials/index.md){ .md-button }
@@ -22,13 +25,33 @@ hero_alt: "Supercharge Microsoft Fabric — Casino & gaming POC + federal expans
 
 This POC is built on three paradigms that define how data flows from source to insight inside Microsoft Fabric.
 
-**OneLake** is the unified storage layer. Every workspace writes Delta and Iceberg tables to a single lake — no data movement, no copy sprawl.
+**OneLake** is the unified storage layer. It's Delta Lake–native — Fabric engines read and write Delta tables to a single lake with no data movement — and interoperates with Apache Iceberg via metadata virtualization (shortcuts and the Iceberg/Delta translation layer), so Iceberg readers and writers can work against the same data.
 
 **Medallion Architecture** (Bronze → Silver → Gold) organizes that data by quality tier. Bronze captures raw ingestion, Silver cleanses and validates, Gold produces business-ready KPIs and star schemas.
 
-**Direct Lake** connects Power BI semantic models straight to Gold-layer Delta tables in OneLake — sub-second queries without import or DirectQuery overhead.
+**Direct Lake** connects Power BI semantic models straight to Gold-layer Delta tables in OneLake — low-latency analytics with no import step and no scheduled refresh. (On large or over-limit models it can fall back to DirectQuery, and cold caches warm on first access.)
 
 Together they give you a single pipeline from raw events to executive dashboards, with governance enforced by Microsoft Purview at every layer.
+
+---
+
+## How this relates to CSA-in-a-Box
+
+<!-- TODO(frank): PLACEHOLDER — confirm and finalize before publishing.
+     1. Replace the (#) links with the real CSA-in-a-Box URL.
+     2. Disambiguate the three brand names so a newcomer isn't lost:
+          - CSA-in-a-Box → ?
+          - CSA Loom      → ?   (the /fiab/ slug — "Fabric-in-a-Box"?)
+          - "fiab"        → ?
+     3. Mirror this same blurb on the CSA-in-a-Box home page so both repos
+        cross-link and tell the same "which repo, when" story. -->
+
+This project is a **Microsoft Fabric reference**: use it once you've committed to Fabric and want hands-on patterns, tutorials, and governance mappings on F64 capacity.
+
+Its sibling, **[CSA-in-a-Box](#)** *(TODO: link)*, takes the **platform-agnostic / build-your-own** angle and includes "vs Microsoft Fabric" comparisons — use it when you're still deciding whether to adopt Fabric, or want a non-Fabric option.
+
+!!! tip "Which one do I use?"
+    **Already on Fabric** → you're in the right place (this repo). **Still choosing a platform, or want a non-Fabric alternative** → start with CSA-in-a-Box. *(Placeholder positioning — Frank to confirm the CSA-in-a-Box vs CSA Loom vs "fiab" naming and finalize the links.)*
 
 ---
 
@@ -48,7 +71,7 @@ Together they give you a single pipeline from raw events to executive dashboards
 
     ---
 
-    37+ hands-on modules from Bronze ingestion to AI/ML
+    50+ self-paced, hands-on tutorials from Bronze ingestion to AI/ML
 
     [:octicons-arrow-right-24: Browse tutorials](tutorials/index.md)
 
@@ -64,7 +87,7 @@ Together they give you a single pipeline from raw events to executive dashboards
 
     ---
 
-    Workshop materials: Foundation → Transformation → BI & Governance
+    A curated subset of the tutorials, packaged as a guided workshop: Foundation → Transformation → BI & Governance
 
     [:octicons-arrow-right-24: View agenda](poc-agenda/README.md)
 
@@ -96,7 +119,7 @@ Together they give you a single pipeline from raw events to executive dashboards
 
     ---
 
-    Purview governance, MICS, CTR/SAR, regulatory reporting
+    Microsoft Purview governance, gaming internal controls (NIGC MICS), and anti-money-laundering reporting (CTR/SAR)
 
     [:octicons-arrow-right-24: Governance tutorial](tutorials/07-governance-purview/README.md)
 
@@ -158,6 +181,9 @@ Together they give you a single pipeline from raw events to executive dashboards
 
 This POC addresses casino/gaming regulations (NIGC MICS, Title 31/BSA, IRS Gaming) and supports **8 federal agency domains** — USDA, SBA, NOAA, EPA, DOI, DOT/FAA, Tribal Healthcare, and DOJ.
 
+!!! warning "These are reference mappings, not authorizations"
+    The compliance and governance pages illustrate how Fabric controls *can* map to each framework, for education and POC scoping. They are **not** ATOs, attestations, audits, or certifications, and they don't represent the compliance posture of any production system.
+
 | Framework | Coverage |
 |:----------|:---------|
 | **NIGC MICS** | Minimum Internal Control Standards |
@@ -201,7 +227,7 @@ This POC addresses casino/gaming regulations (NIGC MICS, Title 31/BSA, IRS Gamin
 
     ---
 
-    F64 capacity breakdown — ~$10,310/month
+    F64 24/7 ≈ $9,500–$12,500/mo (commercial list, as of Jan 2025). Azure Government pricing differs — see the guide.
 
     [:octicons-arrow-right-24: Cost details](COST_ESTIMATION.md)
 
@@ -211,7 +237,7 @@ This POC addresses casino/gaming regulations (NIGC MICS, Title 31/BSA, IRS Gamin
 
 <div align="center" markdown>
 
-**License:** MIT | **Maintained by:** Microsoft Fabric POC Team
+**License:** MIT · **Maintained by:** [Frank Garofalo](https://github.com/fgarofalo56) · A personal/community project — not affiliated with, sponsored by, or endorsed by Microsoft.
 
 [:material-github: View on GitHub](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric){ .md-button }
 

--- a/docs/microsoft-fabric-features-april-2026.md
+++ b/docs/microsoft-fabric-features-april-2026.md
@@ -689,5 +689,5 @@ Features that may NOT be covered yet:
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/docs/use-cases/retail-demand-forecasting.md
+++ b/docs/use-cases/retail-demand-forecasting.md
@@ -438,5 +438,5 @@ FabricAuditLogs
 ---
 
 *Last Updated: 2026-04-27*
-*Author: Fabric POC Team*
+*Author: Frank Garofalo*
 *Compliance Review: PCI-DSS v4.0 scope validated*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,16 @@
 # MkDocs Configuration for Supercharge Microsoft Fabric
 # https://squidfunk.github.io/mkdocs-material/
 
-site_name: Suppercharge Microsoft Fabric
-site_description: Casino/Gaming Industry POC for Microsoft Fabric
-site_author: Microsoft Fabric POC Team
+# NOTE: site_name drives the browser <title>, the OG/Twitter card site_name,
+# and the navbar logo title — keep it spelled "Supercharge" (one p). The repo
+# slug below is still "Suppercharge_…"; renaming that is tracked separately so
+# inbound links / redirects can be handled without breaking shares.
+site_name: Supercharge Microsoft Fabric
+site_description: >-
+  A personal, community reference for Microsoft Fabric — a casino & gaming
+  analytics POC that bridges to Tribal Nations and federal agency data domains.
+  Not an official Microsoft product.
+site_author: Frank Garofalo
 site_url: https://fgarofalo56.github.io/Suppercharge_Microsoft_Fabric/
 
 # Repository

--- a/poc-agenda/DEMO_RUNBOOK.md
+++ b/poc-agenda/DEMO_RUNBOOK.md
@@ -1322,7 +1322,7 @@ After the demo, share this link for feedback:
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
-| 1.0.0 | 2025-01-21 | POC Team | Initial release |
+| 1.0.0 | 2025-01-21 | Frank Garofalo | Initial release |
 
 ---
 

--- a/poc-agenda/instructor-guide/README.md
+++ b/poc-agenda/instructor-guide/README.md
@@ -736,7 +736,7 @@ Collect the following:
 
 | Version | Date | Changes | Author |
 |---------|------|---------|--------|
-| 1.0 | 2026-01-21 | Initial release | POC Team |
+| 1.0 | 2026-01-21 | Initial release | Frank Garofalo |
 
 ---
 

--- a/reports/README.md
+++ b/reports/README.md
@@ -321,5 +321,5 @@ Gold layer tables are pre-aggregated for optimal Direct Lake performance:
 
 ---
 
-> **Documentation maintained by:** Microsoft Fabric POC Team
+> **Documentation maintained by:** Frank Garofalo
 > **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -289,5 +289,5 @@ Before starting the tutorials, ensure you have:
 
 ---
 
-> 📖 **Documentation maintained by:** Microsoft Fabric POC Team
+> 📖 **Documentation maintained by:** Frank Garofalo
 > 🔗 **Repository:** [Suppercharge_Microsoft_Fabric](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric)


### PR DESCRIPTION
Repo-audit remediation — credibility and positioning fixes. No repo rename (deferred by owner decision).

## Branding
- `site_name` corrected to **Supercharge Microsoft Fabric** (one p). This flows to the page `<title>`, the OG/Twitter card `site_name`, and the navbar logo title. Repo slug / `repo_url` / `site_url` intentionally left unchanged.

## Disclaimers (legal/positioning)
- Prominent **"Personal project — not an official Microsoft product"** notice on the docs home and README.
- Explicit **"compliance pages are reference mappings, not authorizations/attestations/certifications"** callouts (home intro + Compliance section).
- All **"Microsoft Fabric POC Team"** / "Maintained by" attributions → **Frank Garofalo**; `site_author` updated.

## Positioning
- Above-the-fold sentence naming the audience + **casino → Tribal Nations → federal** throughline (home + README); updated home `og:description`.

## Accuracy
- OneLake: **Delta-native + Iceberg interop** (was "writes Delta and Iceberg").
- Direct Lake: **"low-latency, no import step"** + DirectQuery-fallback caveat (was "sub-second").
- F64 cost: **dated range + commercial-vs-Gov caveat** (was bare `~$10,310/mo`).
- Tutorial count **50+** reconciled with the **curated 3-day agenda**.
- Expanded **NIGC MICS / CTR / SAR** acronyms on first use.

## Placeholder
- Added a **"How this relates to CSA-in-a-Box"** section, marked `TODO(frank)` for the real URL + CSA Loom/"fiab" disambiguation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)