### PR TITLE
docs(positioning): publicly-sourced disclaimers + competitor de-naming (legal defensibility)

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,8 @@ flowchart LR
     T26 --> T27 --> T28 --> T29 --> T30 --> T31
 ```
 
+> **Note on third-party references:** The migration tutorials (Teradata, Snowflake, IBM DB2) and any platform comparisons reference non-Microsoft products. That information is publicly sourced from each vendor's official documentation and offered for good-faith comparison only; this personal project does not claim authority over those products. Always verify against the vendor's current docs.
+
 <table>
 <tr>
 <th>🎯 Level</th>
@@ -1034,7 +1036,7 @@ flowchart LR
 </tr>
 <tr>
 <td><a href="tutorials/24-snowflake-to-fabric/README.md"><b>24 - Snowflake to Fabric</b></a></td>
-<td>Snowflake migration & cost comparison</td>
+<td>Snowflake migration & cost planning</td>
 <td><code>~3 hours</code></td>
 </tr>
 <tr>

--- a/data_generation/README.md
+++ b/data_generation/README.md
@@ -6,6 +6,11 @@ Synthetic data generators for casino/gaming, federal agencies, streaming CDC, an
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services (for example, IBM DB2 and Oracle as simulated CDC source systems). That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## Overview
 
 ```

--- a/docs/DECISION_TREES.md
+++ b/docs/DECISION_TREES.md
@@ -10,6 +10,9 @@ type: decision
 
 This document provides structured decision flowcharts for the most common "which Fabric component should I use?" questions. Each section contains a Mermaid flowchart, a comparison table, a "Choose X when..." summary, and a real-world example drawn from the POC.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 1. Lakehouse vs Warehouse vs SQL Database
@@ -211,9 +214,9 @@ See: [Spark Environments & Job Definitions](features/spark-environments-job-defi
 ```mermaid
 flowchart TD
     A[External data source<br/>needs to reach Fabric] --> B{Source type?}
-    B -->|"Azure SQL, Cosmos DB,<br/>Snowflake, supported DB"| C{Need continuous<br/>near-real-time sync?}
+    B -->|"Azure SQL, Cosmos DB,<br/>supported databases"| C{Need continuous<br/>near-real-time sync?}
     B -->|"ADLS Gen2, S3,<br/>GCS, Dataverse"| D{Need to copy<br/>or just reference?}
-    B -->|"On-prem SQL Server,<br/>Oracle, DB2"| E[Pipeline Copy Activity<br/>via Data Gateway]
+    B -->|"On-prem SQL Server<br/>or other relational DBs"| E[Pipeline Copy Activity<br/>via Data Gateway]
     C -->|Yes, CDC/change feed| F[Mirroring]
     C -->|No, periodic sync OK| G{Acceptable latency?}
     G -->|Minutes| H[Pipeline Copy<br/>with incremental load]
@@ -233,7 +236,7 @@ flowchart TD
 |---|---|---|---|
 | **Data Movement** | Continuous replication | No movement (reference) | Scheduled copy |
 | **Latency** | Near-real-time (seconds-minutes) | Zero (reads source directly) | Minutes to hours |
-| **Supported Sources** | Azure SQL, Cosmos DB, Snowflake, more | ADLS, S3, GCS, Dataverse, OneLake | Any (via connectors + gateways) |
+| **Supported Sources** | Azure SQL, Cosmos DB, and other supported databases | ADLS, S3, GCS, Dataverse, OneLake | Any (via connectors + gateways) |
 | **Data Ownership** | Replicated copy in OneLake | Source owns data | Copied to OneLake |
 | **Transformation** | None (raw replication) | None (passthrough) | Full ETL in pipeline |
 | **Cost** | Replication CU + storage | Minimal (query-time CU only) | Copy CU + storage |
@@ -242,7 +245,7 @@ flowchart TD
 
 ### Choose X When...
 
-- **Choose Mirroring** when you need continuous, near-real-time replication from a supported database (Azure SQL, Cosmos DB, Snowflake) without building custom CDC pipelines. Data is automatically converted to Delta format in OneLake.
+- **Choose Mirroring** when you need continuous, near-real-time replication from a supported database (for example, Azure SQL or Cosmos DB, among other supported sources) without building custom CDC pipelines. Data is automatically converted to Delta format in OneLake.
 - **Choose Shortcuts** when you want to query data in-place without copying it, the source is ADLS Gen2/S3/GCS/Dataverse, and you want to avoid storage duplication. Ideal for cross-workspace or cross-cloud data federation.
 - **Choose Pipeline Copy** when the source requires a data gateway (on-premises), you need transformation during ingestion, the source is not supported by mirroring or shortcuts, or you need full control over scheduling and error handling.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -16,6 +16,9 @@ type: reference
 
 </div>
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 !!! tip "Looking for answers to specific operational questions?"
@@ -1556,6 +1559,12 @@ See: [Data Agents](features/data-agents.md) | [Fabric IQ](features/fabric-iq.md)
 ---
 
 ## 🔄 Migrations
+
+> **Note on third-party platforms.** The migration notes below describe how to move
+> *into* Microsoft Fabric. Details about each source platform are summarized from
+> that vendor's publicly available documentation and may change; always confirm
+> against the vendor's current official docs. Nothing here claims expertise in, or
+> authority over, those third-party products.
 
 ### How do I migrate from Synapse Analytics?
 

--- a/docs/FIELD_QUESTIONS.md
+++ b/docs/FIELD_QUESTIONS.md
@@ -24,6 +24,9 @@ Fabric adoption — scenarios that the standard product docs don't address direc
 but that come up repeatedly in field engagements. Each topic links back to the
 authoritative Microsoft Learn citation.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 1. Power BI Mashup Errors with Mixed VNet + Cloud Sources

--- a/docs/GENERATOR_API_REFERENCE.md
+++ b/docs/GENERATOR_API_REFERENCE.md
@@ -18,6 +18,9 @@ type: reference
 
 **TL;DR** -- This document covers all 19 data generators in the `data_generation/generators/` package. Every generator inherits from `BaseGenerator`, which provides reproducible seeding, output serialization (DataFrame, Parquet, JSON), batch iteration, and PII masking helpers. Generators span four domains: Casino/Gaming (6), Federal Agency (7), Analytics (3), and Streaming (3).
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## # BaseGenerator Interface

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -16,6 +16,9 @@ type: reference
 
 </div>
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 🔷 Microsoft Fabric Terms

--- a/docs/MIGRATION_AND_RTI_RESEARCH.md
+++ b/docs/MIGRATION_AND_RTI_RESEARCH.md
@@ -19,6 +19,9 @@ type: deep-dive
 > Research compiled: 2026-03-11
 > Sources: Microsoft Learn, Brave Web Search, Microsoft Docs MCP
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 🏗️ Part 1: Database Migration Paths to Microsoft Fabric
@@ -294,15 +297,17 @@ Microsoft offers multiple pathways for Snowflake integration/migration, ranging 
 
 #### Cost Comparison Considerations
 
-| Factor | Snowflake | Microsoft Fabric |
-|--------|-----------|-----------------|
+The table below contrasts a referenced competitor's published pricing and capability model with Microsoft Fabric. The competitor's details are summarized in good faith from its publicly available documentation; the two platforms take different but each valid architectural approaches, so the right choice depends on workload and existing investments. Always verify the competitor's current pricing against its official documentation.
+
+| Factor | Referenced competitor | Microsoft Fabric |
+|--------|-----------------------|-----------------|
 | Pricing Model | Per-second compute + storage | Capacity Units (CU) - single SKU |
 | Data Storage | Per-TB/month | Included in capacity (OneLake) |
-| Compute Scaling | Auto-scale warehouses | Capacity-based, workload management |
-| Cross-workload | Separate tools needed | Unified platform (DW, DE, DS, BI) |
-| Real-Time | Snowpipe + Streams | Eventstreams + Eventhouse (native) |
-| BI | Requires external tool | Power BI included natively |
-| Governance | Snowflake governance | Microsoft Purview (integrated) |
+| Compute Scaling | Auto-scale warehouses (mature, granular) | Capacity-based, workload management |
+| Cross-workload | Strong analytics engine; BI/DE via partner tools | Unified platform (DW, DE, DS, BI) |
+| Real-Time | Continuous-ingest + change-stream features | Eventstreams + Eventhouse (native) |
+| BI | Pairs with external BI tools | Power BI included natively |
+| Governance | Native governance features | Microsoft Purview (integrated) |
 
 #### Sample Migration Steps (5-Phase)
 

--- a/docs/MY_RESOURCES.md
+++ b/docs/MY_RESOURCES.md
@@ -7,6 +7,9 @@ type: reference
 
 > Per-deployment reference sheet. Fill in your **own** Azure resource IDs locally so every tutorial pulls from one place instead of hunting through multiple portals.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 !!! warning "Do not commit real values to this file"
     The template below uses placeholders only. **Keep your real GUIDs, tenant IDs, subscription IDs, resource names, and managed-identity object IDs out of this file before committing.** Connection strings, access keys, SAS tokens, and any other secrets belong in Key Vault and should be referenced by **secret name only** from your notebooks and pipelines.
 

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -16,6 +16,9 @@ type: deep-dive
 
 </div>
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 🎯 Overview

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,6 +21,9 @@ type: deep-dive
 
 **Last Updated:** `2025-01-21` | **Version:** 1.0.0
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 🛡️ Security Architecture

--- a/docs/best-practices/06_DATAFLOWS.md
+++ b/docs/best-practices/06_DATAFLOWS.md
@@ -19,6 +19,11 @@ type: deep-dive
 </div>
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📋 Overview
 
 Dataflows Gen2 provides a low-code/no-code experience for data transformation using Power Query. This guide covers query folding, staging, fast copy, and performance optimization techniques.

--- a/docs/best-practices/07_LAKEHOUSE_SETUP.md
+++ b/docs/best-practices/07_LAKEHOUSE_SETUP.md
@@ -19,6 +19,11 @@ type: deep-dive
 </div>
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📋 Overview
 
 The Lakehouse is central to Microsoft Fabric's data architecture, combining data lake flexibility with data warehouse capabilities. This guide covers Delta Lake configuration, medallion architecture implementation, and table maintenance best practices.

--- a/docs/best-practices/10_DECISION_GUIDE.md
+++ b/docs/best-practices/10_DECISION_GUIDE.md
@@ -17,6 +17,10 @@ type: deep-dive
 ![Last Updated](https://img.shields.io/badge/Updated-April_2026-blue?style=for-the-badge)
 
 </div>
+
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 📋 Overview
@@ -128,7 +132,7 @@ flowchart TD
 
 ### Scenario 1: Enterprise Data Warehouse Migration
 
-**Context:** Migrating from on-premises Oracle/SQL Server to Fabric
+**Context:** Migrating from an on-premises relational database (such as SQL Server or another vendor's RDBMS) to Fabric
 
 **Recommendation:**
 ```

--- a/docs/best-practices/README.md
+++ b/docs/best-practices/README.md
@@ -11,11 +11,14 @@
 
 </div>
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 📖 Overview
 
-This comprehensive guide provides best practices for all aspects of Microsoft Fabric implementation. Whether you're setting up workspaces, designing data pipelines, optimizing Spark jobs, or migrating from Oracle/SQL Server, this guide covers proven patterns and recommendations based on Microsoft's official guidance.
+This comprehensive guide provides best practices for all aspects of Microsoft Fabric implementation. Whether you're setting up workspaces, designing data pipelines, optimizing Spark jobs, or migrating data in from external relational databases (such as Oracle Database or SQL Server), this guide covers proven patterns and recommendations based on Microsoft's official guidance.
 
 ---
 

--- a/docs/best-practices/data-management/data-product-framework.md
+++ b/docs/best-practices/data-management/data-product-framework.md
@@ -22,6 +22,11 @@ type: deep-dive
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 For most of the last decade, data was treated as a **byproduct** — exhaust from operational systems that a central data team scraped together into reports. The pattern broke at scale: central teams became bottlenecks, data quality lived nowhere, consumers had no way to know whether a table was "trustworthy" or "someone's experiment from 2022", and ownership was a finger-pointing exercise. The **Data Product** discipline reframes the question. A data set with no owner, no SLA, no contract, and no lifecycle is not a data product — it's organizational risk pretending to be an asset.

--- a/docs/best-practices/data-management/late-arriving-data.md
+++ b/docs/best-practices/data-management/late-arriving-data.md
@@ -22,6 +22,11 @@ type: deep-dive
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 Real-world data does not arrive in order. Mobile devices buffer events while offline. Source systems publish corrections days later. Bug fixes require replaying months of history. Bureaucratic processes restate "final" numbers as estimates and then again as audited values. **Late-arriving data is not an exception — it is the default condition of any non-trivial pipeline.**

--- a/docs/best-practices/data-management/reference-data-versioning.md
+++ b/docs/best-practices/data-management/reference-data-versioning.md
@@ -22,6 +22,11 @@ type: deep-dive
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 What Is Reference Data
 
 **Reference data** is the set of permissible values that classify, qualify, or constrain other data. It defines the vocabulary the rest of your data speaks. Currency codes, country codes, product hierarchies, NAICS codes, jurisdiction tax tables, GL chart of accounts — all reference data.

--- a/docs/best-practices/data-sharing-federation.md
+++ b/docs/best-practices/data-sharing-federation.md
@@ -21,6 +21,11 @@ type: deep-dive
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 Data sharing and federation in Microsoft Fabric enables organizations to provide governed access to data across workspace, organizational, and cloud boundaries without copying data. This guide covers OneLake shortcuts, Fabric data sharing, Iceberg endpoint federation, and external catalog integration patterns for casino gaming and federal agency workloads.

--- a/docs/best-practices/etl-elt-comparison-guide.md
+++ b/docs/best-practices/etl-elt-comparison-guide.md
@@ -15,6 +15,9 @@ type: deep-dive
 
 </div>
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 **Last Updated:** `2026-04-21` | **Version:** 1.0.0
@@ -326,8 +329,8 @@ Spark Notebook ────► Dataflow Gen2
 | SSIS packages | Spark Notebook | SQL Server migration | High (rewrite) |
 | SSIS packages | Dataflow Gen2 | SQL Server migration | Medium (visual rebuild) |
 | Power BI Dataflows | Dataflow Gen2 | Power BI → Fabric migration | Low (same M language) |
-| ADB Notebooks | Spark Notebooks | Databricks → Fabric migration | Medium (runtime differences) |
-| Informatica / Talend | Dataflow Gen2 or Notebook | Legacy ETL modernization | High (rebuild) |
+| Competitor Spark notebooks | Spark Notebooks | Competitor lakehouse → Fabric migration | Medium (runtime differences) |
+| Third-party legacy ETL tools | Dataflow Gen2 or Notebook | Legacy ETL modernization | High (rebuild) |
 
 ---
 

--- a/docs/best-practices/incremental-refresh-cdc.md
+++ b/docs/best-practices/incremental-refresh-cdc.md
@@ -21,6 +21,11 @@ type: deep-dive
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 Incremental refresh and change data capture (CDC) patterns are essential for production-grade data pipelines that must process only new or changed data rather than reloading entire datasets. This guide covers Delta Lake MERGE operations, watermark-based change detection, SCD Type 1 and Type 2 implementations, and Power BI semantic model incremental refresh — all tuned for casino gaming and federal agency workloads in Microsoft Fabric.

--- a/docs/best-practices/lakehouse-warehouse-sqldb-decision-guide.md
+++ b/docs/best-practices/lakehouse-warehouse-sqldb-decision-guide.md
@@ -15,6 +15,9 @@ type: deep-dive
 
 </div>
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 **Last Updated:** `2026-04-21` | **Version:** 1.0.0
@@ -539,9 +542,9 @@ flowchart TB
 | Azure SQL Database | SQL Database (mirror) or Lakehouse (shortcut) | Mirroring or Shortcut |
 | Azure Synapse (dedicated pool) | Warehouse | Pipeline migration |
 | Azure Data Lake Gen2 | Lakehouse | Shortcut (zero-copy) |
-| Databricks Delta Lake | Lakehouse | Shortcut or Pipeline |
+| Competitor lakehouse (Delta tables) | Lakehouse | Shortcut or Pipeline |
 | On-premises SQL Server | SQL Database or Warehouse | Pipeline + Gateway |
-| Snowflake | Warehouse or Lakehouse | Pipeline |
+| Competitor cloud data warehouse | Warehouse or Lakehouse | Pipeline |
 
 ---
 

--- a/docs/best-practices/migration-patterns.md
+++ b/docs/best-practices/migration-patterns.md
@@ -7,7 +7,7 @@ type: deep-dive
 
 <div align="center" markdown>
 
-**Structured Migration Playbook from Legacy Analytics to Microsoft Fabric**
+**Structured Migration Playbook from Existing Analytics Platforms to Microsoft Fabric**
 
 ![Category](https://img.shields.io/badge/Category-Migration-teal?style=for-the-badge)
 ![Status](https://img.shields.io/badge/Status-Complete-success?style=for-the-badge)
@@ -35,9 +35,14 @@ type: deep-dive
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
-Migrating to Microsoft Fabric from legacy analytics platforms requires a structured approach that minimizes risk, preserves data fidelity, and captures the full value of Fabric's unified platform. This guide provides battle-tested migration patterns for moving from Oracle, SQL Server, Teradata, SAS, Snowflake, Databricks, and Azure Synapse Analytics into Fabric's Lakehouse, Warehouse, and Eventhouse workloads.
+Migrating to Microsoft Fabric from another analytics platform benefits from a structured approach that minimizes risk and preserves data fidelity. This guide provides migration patterns for moving from Oracle, SQL Server, Teradata, SAS, Snowflake, Databricks, and Azure Synapse Analytics into Fabric's Lakehouse, Warehouse, and Eventhouse workloads. Each of these source platforms is a capable, well-established product, and many remain excellent choices in their own right; the guidance below describes how to move a workload to Fabric when that is the chosen direction. Source-platform behavior, component names, and feature mappings are based on each vendor's publicly available documentation (as of this doc's date) — always verify against the vendor's current official documentation.
 
 ### Migration Principles
 
@@ -518,7 +523,7 @@ Snowflake migrations can leverage Iceberg table endpoints for zero-copy reads or
 
 ### Databricks Migration Pattern
 
-Databricks-to-Fabric migrations are the smoothest because both platforms use Delta Lake natively.
+Databricks-to-Fabric migrations are often relatively low-friction because both platforms use Delta Lake natively. Databricks is a strong, mature lakehouse and ML platform; the notes below describe the mechanics of moving to Fabric, not a judgment that one platform is universally better.
 
 **Option A: ADLS Shortcuts (zero-copy)**
 
@@ -541,7 +546,7 @@ For cross-cloud or cross-organization sharing, use the Delta Sharing protocol.
 
 ### 🔷 Azure Synapse Analytics Migration Pattern
 
-Azure Synapse → Fabric is the **most-asked enterprise migration** because Synapse and Fabric share Microsoft DNA, but the architectural shift from DWUs to CUs and from Spark/SQL silos to a unified capacity is real. The migration pivots on three big wins: Dedicated SQL pool DDL converts cleanly to Fabric Warehouse (drop the `DISTRIBUTION` and `CLUSTERED COLUMNSTORE` clauses; Fabric handles those automatically via V-Order), ADLS Gen2 storage moves to OneLake via shortcut (no data copy), and Synapse Spark notebooks port with mostly mechanical `mssparkutils` adjustments.
+Azure Synapse → Fabric is one of the **most common enterprise migrations** because Synapse and Fabric share Microsoft DNA (both are Microsoft platforms, so this is not a third-party migration), but the architectural shift from DWUs to CUs and from Spark/SQL silos to a unified capacity is real. The migration pivots on three big wins: Dedicated SQL pool DDL converts cleanly to Fabric Warehouse (drop the `DISTRIBUTION` and `CLUSTERED COLUMNSTORE` clauses; Fabric handles those automatically via V-Order), ADLS Gen2 storage moves to OneLake via shortcut (no data copy), and Synapse Spark notebooks port with mostly mechanical `mssparkutils` adjustments.
 
 **Detailed playbook:** [Tutorial 41 — Synapse → Fabric](../tutorials/41-synapse-to-fabric/README.md)
 
@@ -579,13 +584,13 @@ Azure Synapse → Fabric is the **most-asked enterprise migration** because Syna
 | DW6000c | F256 |
 | DW15000c | F1024 |
 
-> 💡 **When to use this approach:** Existing Azure Synapse Analytics estate (Dedicated SQL pool, Spark pool, or both). Goal is unified capacity model, Direct Lake BI, and elimination of Spark/SQL billing silos. Synapse SQL pools are entering sustaining mode — Fabric is where new investment lands. Validate F-SKU sizing empirically during coexistence; CU pool also serves Power BI and RTI.
+> 💡 **When to use this approach:** Existing Azure Synapse Analytics estate (Dedicated SQL pool, Spark pool, or both). Goal is unified capacity model, Direct Lake BI, and consolidation of Spark/SQL billing. Per Microsoft's public guidance, new analytics investment is increasingly directed at Fabric; confirm the current support and roadmap position for Synapse against Microsoft's official documentation. Validate F-SKU sizing empirically during coexistence; CU pool also serves Power BI and RTI.
 
 ---
 
 ### 🧱 Databricks Migration Pattern (Detailed)
 
-Databricks → Fabric is the **smoothest cloud-to-cloud migration** because both platforms speak Delta Lake natively. The technical lift is small; the strategic question is bigger — moving onto a Microsoft platform that bundles BI, real-time, governance, and ML alongside Spark, with a single capacity-based commercial model. The migration pivots on Delta-table movement (shortcut-in-place or rewrite for V-Order), Unity Catalog → OneLake Catalog governance translation, `dbutils` → `mssparkutils` shim, Workflows → Fabric Pipelines, and MLflow registry export-import.
+Databricks → Fabric is often a **relatively low-friction cloud-to-cloud migration** because both platforms speak Delta Lake natively. Databricks is a capable, widely adopted lakehouse and ML platform with deep Spark and MLflow heritage, and remains the right choice for many teams. The technical lift of moving to Fabric is typically small; the strategic question is bigger — whether a Microsoft platform that bundles BI, real-time, governance, and ML alongside Spark, with a single capacity-based commercial model, fits your needs better. The migration pivots on Delta-table movement (shortcut-in-place or rewrite for V-Order), Unity Catalog → OneLake Catalog governance translation, `dbutils` → `mssparkutils` shim, Workflows → Fabric Pipelines, and MLflow registry export-import.
 
 **Detailed playbook:** [Tutorial 42 — Databricks → Fabric](../tutorials/42-databricks-to-fabric/README.md)
 
@@ -606,9 +611,11 @@ Databricks → Fabric is the **smoothest cloud-to-cloud migration** because both
 | Cluster pools (DBU) | Fabric Spark capacity (CU) | Auto-scales within F-SKU |
 | Photon engine | V-Order + Native Execution Engine | Different code path, similar perf |
 
-#### V-Order Benefits (vs. Photon-only Optimization)
+#### V-Order and Direct Lake vs. Photon Optimization (per public docs)
 
-| Benefit | Databricks | Fabric |
+The comparison below reflects each platform's publicly documented behavior; the approaches differ in design rather than one being strictly superior. Verify current behavior against each vendor's official documentation.
+
+| Aspect | Databricks | Fabric |
 |---------|-----------|--------|
 | BI hot-path latency | Photon cluster + cached | Direct Lake (no copy, no refresh) |
 | File compaction | `OPTIMIZE` (compaction only) | `OPTIMIZE table VORDER` (V-Order + compaction) |
@@ -632,7 +639,7 @@ Databricks → Fabric is the **smoothest cloud-to-cloud migration** because both
 
 ### 🟧 Amazon Redshift Migration Pattern
 
-Amazon Redshift → Fabric is a **multi-cloud migration** — increasingly common as enterprises consolidate analytics estates onto Microsoft Fabric while keeping operational workloads in AWS. The migration pivots on `UNLOAD` to S3 (Parquet/Snappy), OneLake shortcuts to S3 (zero-copy, zero AWS egress on shortcuts), Redshift PostgreSQL DDL → Fabric T-SQL, and **stripping** Redshift-specific physical tuning clauses (`DISTKEY`, `SORTKEY`, `ENCODE`) which V-Order replaces automatically. Spectrum external tables are the cheapest part of the migration — same S3 prefix becomes a OneLake shortcut with no data movement.
+Amazon Redshift → Fabric is a **multi-cloud migration** — one that some enterprises pursue when consolidating analytics estates onto Microsoft Fabric while keeping operational workloads in AWS. Amazon Redshift is a mature, high-performance cloud data warehouse, and Redshift Spectrum's S3-native model is a genuine strength that this approach builds on rather than replaces. The migration pivots on `UNLOAD` to S3 (Parquet/Snappy), OneLake shortcuts to S3 (zero-copy, zero AWS egress on shortcuts), Redshift PostgreSQL DDL → Fabric T-SQL, and **stripping** Redshift-specific physical tuning clauses (`DISTKEY`, `SORTKEY`, `ENCODE`) which V-Order replaces automatically. Spectrum external tables are the cheapest part of the migration — same S3 prefix becomes a OneLake shortcut with no data movement.
 
 **Detailed playbook:** [Tutorial 43 — Redshift → Fabric](../tutorials/43-redshift-to-fabric/README.md)
 
@@ -674,7 +681,7 @@ Spectrum tables already live as files on S3. The fastest possible migration: cre
 
 ### 🔵 Google BigQuery Migration Pattern
 
-Google BigQuery → Fabric is a **multi-cloud migration** where dialect translation and cross-cloud egress are the two dominant cost drivers. The migration pivots on BigQuery `EXPORT DATA OPTIONS(format='PARQUET')` to GCS, OneLake shortcuts to GCS during coexistence (zero copy), Standard SQL → T-SQL dialect translation (the translator handles ~80% mechanically), partitioning + clustering → Delta partitioning + Z-Order, and JS UDFs → PySpark notebook UDFs. STRUCT and ARRAY columns are the hardest type-mapping problem — T-SQL has no native equivalents, so they land as JSON `varchar(max)` or move to Lakehouse for native Spark complex-type handling.
+Google BigQuery → Fabric is a **multi-cloud migration** where dialect translation and cross-cloud egress are the two dominant cost drivers. BigQuery is a powerful, highly scalable serverless warehouse with strong native support for nested STRUCT/ARRAY data; this approach is about moving to Fabric where that fits an organization's strategy, not a claim that one platform is universally better. The migration pivots on BigQuery `EXPORT DATA OPTIONS(format='PARQUET')` to GCS, OneLake shortcuts to GCS during coexistence (zero copy), Standard SQL → T-SQL dialect translation (the translator handles ~80% mechanically), partitioning + clustering → Delta partitioning + Z-Order, and JS UDFs → PySpark notebook UDFs. STRUCT and ARRAY columns are the hardest type-mapping problem — T-SQL has no native equivalents, so they land as JSON `varchar(max)` or move to Lakehouse for native Spark complex-type handling.
 
 **Detailed playbook:** [Tutorial 44 — BigQuery → Fabric](../tutorials/44-bigquery-to-fabric/README.md)
 
@@ -1075,7 +1082,7 @@ def generate_validation_report(
 
 ### TCO Template
 
-Use this template to compare legacy platform costs against Microsoft Fabric for equivalent workloads.
+Use this template to compare your source platform's costs against Microsoft Fabric for equivalent workloads. The template is a neutral worksheet — it does not assert that Fabric is cheaper. Outcomes vary widely by workload, licensing, reservations, and region; the "Savings" column may be positive or negative for a given organization. Populate it with your own verified figures and your source vendor's current pricing rather than assuming a result.
 
 | Cost Category | Legacy Platform | Microsoft Fabric | Savings |
 |--------------|-----------------|------------------|---------|

--- a/docs/best-practices/network-security.md
+++ b/docs/best-practices/network-security.md
@@ -21,6 +21,11 @@ type: deep-dive
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 Microsoft Fabric operates as a SaaS platform with multiple network security layers to control data access, protect data in transit, and isolate workloads. A defense-in-depth strategy combines Private Endpoints, Managed VNet, IP Firewall rules, and on-premises connectivity to meet enterprise and government security requirements.

--- a/docs/best-practices/security/audit-trail-immutability.md
+++ b/docs/best-practices/security/audit-trail-immutability.md
@@ -22,6 +22,9 @@ type: compliance
 
 > **Disclaimer:** This document provides architectural and technical guidance for audit-trail immutability on Microsoft Fabric. It is **not** legal advice, regulatory interpretation, or a guarantee of compliance with any specific statute (SOX, HIPAA, GDPR, PCI-DSS, 21 CFR Part 11, NIGC MICS, FedRAMP). Audit-evidence requirements vary by jurisdiction, regulator, and contract. Engage qualified legal counsel and your audit firm before relying on these patterns to satisfy any specific obligation.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 🎯 Overview: Why Audit Immutability

--- a/docs/best-practices/security/data-exfiltration-prevention.md
+++ b/docs/best-practices/security/data-exfiltration-prevention.md
@@ -22,6 +22,9 @@ type: compliance
 
 > **Disclaimer:** This document describes architectural and technical controls to reduce the likelihood and impact of data exfiltration. It is not a guarantee. A determined insider with sufficient privilege can defeat any control. Layered defense, behavior monitoring, and process controls are equally important. Engage your security and legal teams before relying on these patterns in regulated environments.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 🎯 Overview — The Exfiltration Threat Model

--- a/docs/best-practices/security/onelake-defense-in-depth.md
+++ b/docs/best-practices/security/onelake-defense-in-depth.md
@@ -12,6 +12,9 @@ type: best-practice
 > Direct Lake fallback gotcha, and the canonical configuration vector for
 > each layer (UI / REST / T-SQL / Bicep).
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## The eight layers, at a glance

--- a/docs/best-practices/security/supply-chain-security.md
+++ b/docs/best-practices/security/supply-chain-security.md
@@ -22,6 +22,9 @@ type: compliance
 
 > **Disclaimer:** This document provides architectural and technical guidance for supply chain security on Microsoft Fabric. It is **not** a substitute for a formal third-party risk management program, secure software development lifecycle (SSDLC) certification, or legal counsel. Coordinate with your organization's CISO, procurement, and legal teams before relying on these patterns in regulated environments.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 🎯 Overview: The Supply Chain Threat Landscape

--- a/docs/decisions/etl-elt-streaming.md
+++ b/docs/decisions/etl-elt-streaming.md
@@ -15,6 +15,9 @@ type: decision
 
 </div>
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 **Last Updated:** `2026-05-05` | **Version:** 1.0.0
@@ -30,7 +33,7 @@ Use **ELT** as the default pattern in Fabric -- land raw data in OneLake first, 
 ## When This Question Comes Up
 
 - Designing the initial data ingestion architecture for a new Fabric workspace
-- Migrating SSIS, ADF, or Informatica pipelines to Fabric
+- Migrating SSIS, ADF, or third-party legacy ETL pipelines to Fabric
 - A stakeholder demands "real-time" dashboards and you need to assess if streaming is justified
 - Data sources include a mix of batch databases, file drops, APIs, and event streams
 - Compliance requires PII to be stripped before data lands in the lakehouse

--- a/docs/decisions/fabric-databricks-synapse.md
+++ b/docs/decisions/fabric-databricks-synapse.md
@@ -1,9 +1,9 @@
 ---
 hero: assets/heroes/decisions.svg
-hero_alt: Decision — Fabric vs Databricks vs Synapse
+hero_alt: Decision — Fabric vs a Lakehouse/ML Competitor vs Synapse
 type: decision
 ---
-# Fabric vs Databricks vs Synapse
+# Fabric vs a Lakehouse/ML Competitor vs Synapse
 
 <div align="center" markdown>
 
@@ -15,6 +15,9 @@ type: decision
 
 </div>
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 **Last Updated:** `2026-05-05` | **Version:** 1.0.0
@@ -23,7 +26,7 @@ type: decision
 
 ## TL;DR
 
-Choose **Fabric** when you want a unified SaaS analytics platform with integrated Lakehouse, Warehouse, Power BI, and Real-Time Intelligence under one capacity. Choose **Databricks** when your workload is ML/AI-heavy, multi-cloud, or requires Unity Catalog governance already in place. Keep **Synapse Analytics** for existing dedicated SQL pool investments, but plan migration to Fabric for new workloads.
+Choose **Fabric** when you want a unified SaaS analytics platform with integrated Lakehouse, Warehouse, Power BI, and Real-Time Intelligence under one capacity. Consider **a referenced lakehouse/ML competitor** when your workload is ML/AI-heavy, multi-cloud, or already standardized on that platform's catalog and governance — in those cases it is often the stronger choice. Keep **Azure Synapse Analytics** for existing dedicated SQL pool investments, but plan migration to Fabric for new workloads.
 
 ---
 
@@ -31,8 +34,8 @@ Choose **Fabric** when you want a unified SaaS analytics platform with integrate
 
 - Greenfield project selecting a primary analytics platform on Azure
 - Existing Synapse workspace evaluating migration to Fabric
-- Organization uses Databricks on AWS/GCP and is considering Azure consolidation
-- Team needs to justify Fabric adoption vs expanding existing Databricks investment
+- Organization runs a competitor's lakehouse/ML platform on other clouds and is considering Azure consolidation
+- Team needs to weigh Fabric adoption vs expanding an existing competitor investment
 - Multi-cloud strategy requires interoperability between Fabric and external platforms
 
 ---
@@ -45,13 +48,13 @@ flowchart TD
 
     EXISTING -->|"Greenfield - no<br/>existing platform"| WORKLOAD
     EXISTING -->|Synapse Analytics| SYNAPSE_CHECK{Dedicated SQL pools<br/>or Serverless only?}
-    EXISTING -->|Databricks| DB_CHECK{Multi-cloud<br/>requirement?}
+    EXISTING -->|Competitor lakehouse/ML| DB_CHECK{Multi-cloud<br/>requirement?}
     EXISTING -->|Other / on-prem| WORKLOAD
 
     SYNAPSE_CHECK -->|"Dedicated SQL pools<br/>active workloads"| SYNAPSE_KEEP[Keep Synapse Dedicated<br/>+ evaluate Fabric migration]
     SYNAPSE_CHECK -->|Serverless / Spark only| FABRIC_MIGRATE[Migrate to Fabric<br/>Lakehouse + Warehouse]
 
-    DB_CHECK -->|"Yes - AWS, GCP,<br/>Azure all needed"| DB_MULTI[Databricks<br/>multi-cloud Unity Catalog]
+    DB_CHECK -->|"Yes - multiple<br/>clouds needed"| DB_MULTI[Competitor platform<br/>multi-cloud governance]
     DB_CHECK -->|No - Azure only| WORKLOAD
 
     WORKLOAD{Primary workload?} --> WL_ANALYTICS{Analytics + BI<br/>dominant?}
@@ -62,7 +65,7 @@ flowchart TD
     WL_ML -->|"Yes - training,<br/>MLOps, serving"| ML_SCALE{Scale of ML<br/>operations?}
     WL_ML -->|No| WL_STREAMING{Real-time<br/>streaming dominant?}
 
-    ML_SCALE -->|"Enterprise MLOps,<br/>GPU clusters, LLM fine-tuning"| DATABRICKS[Databricks<br/>ML-optimized platform]
+    ML_SCALE -->|"Enterprise MLOps,<br/>GPU clusters, LLM fine-tuning"| DATABRICKS[Competitor Lakehouse/ML<br/>ML-optimized platform]
     ML_SCALE -->|"Lightweight ML,<br/>AutoML, scoring"| FABRIC
 
     WL_STREAMING -->|Yes| FABRIC
@@ -72,7 +75,7 @@ flowchart TD
     TEAM -->|"Open source,<br/>multi-cloud, Spark-heavy"| DATABRICKS
 
     FABRIC --> FABRIC_DONE[Fabric<br/>OneLake + Spark + Power BI<br/>+ Real-Time Intelligence]
-    DATABRICKS --> DB_DONE[Databricks<br/>Unity Catalog + MLflow<br/>+ Delta Sharing]
+    DATABRICKS --> DB_DONE[Competitor platform<br/>unified catalog + MLOps<br/>+ open data sharing]
 
     style FABRIC_DONE fill:#4CAF50,color:#fff
     style DB_DONE fill:#FF5722,color:#fff
@@ -108,49 +111,49 @@ flowchart TD
 | **Cost** | Capacity-based (F64+); predictable but requires right-sizing; can be expensive for burst ML |
 | **Latency** | Excellent for analytics and streaming; not optimized for heavy ML training |
 | **Compliance** | Strong Azure/FedRAMP posture; Purview integration for lineage and classification |
-| **Skill match** | Ideal for T-SQL + Power BI teams; PySpark supported but Databricks has deeper Spark ecosystem |
+| **Skill match** | Ideal for T-SQL + Power BI teams; PySpark supported, though a dedicated lakehouse/ML competitor typically offers a deeper, more mature Spark ecosystem |
 
 ### Anti-patterns
 
-- Running large-scale ML training (GPU clusters, LLM fine-tuning) on Fabric Spark instead of Databricks
-- Choosing Fabric solely for Spark workloads when the team has deep Databricks expertise and Unity Catalog
+- Running large-scale ML training (GPU clusters, LLM fine-tuning) on Fabric Spark when a competitor's purpose-built ML platform would handle it more efficiently
+- Choosing Fabric solely for Spark workloads when the team already has deep expertise in a competitor's platform and its governance catalog
 - Ignoring Fabric's capacity limits for concurrent users -- under-provisioning leads to throttling
 - Treating Fabric as "just a Lakehouse" and not leveraging Real-Time Intelligence, Data Activator, or Copilot
 
 ---
 
-## Databricks
+## A Referenced Lakehouse/ML Competitor
 
 ### When
 
-- ML/AI is the dominant workload: model training, MLflow experiment tracking, GPU clusters
-- Multi-cloud strategy requires consistent platform across AWS, GCP, and Azure
-- Unity Catalog is already the governance layer for data and ML assets
-- Team is deeply invested in open-source Spark ecosystem and Delta Sharing
+- ML/AI is the dominant workload: model training, experiment tracking, GPU clusters
+- Multi-cloud strategy requires a consistent platform across several cloud providers
+- The competitor's governance catalog is already the layer for data and ML assets
+- Team is deeply invested in the open-source Spark ecosystem and the platform's data-sharing protocol
 
 ### Why
 
-- Purpose-built for ML/AI: GPU-optimized clusters, MLflow, Feature Store, Model Serving
-- Multi-cloud: identical experience on AWS, GCP, Azure
-- Unity Catalog provides unified governance across data, ML models, and notebooks
-- Delta Sharing enables secure cross-organization data sharing without copying
+- Purpose-built for ML/AI: GPU-optimized clusters, experiment tracking, feature store, model serving — genuinely strong for heavy ML/AI work
+- Multi-cloud: a consistent experience across multiple cloud providers
+- A unified governance catalog spanning data, ML models, and notebooks
+- An open data-sharing protocol enables secure cross-organization sharing without copying
 - Mature Spark ecosystem with extensive third-party integrations
 
 ### Tradeoffs
 
 | Dimension | Assessment |
 |-----------|------------|
-| **Cost** | DBU-based pricing; GPU clusters can be expensive; separate BI tooling cost |
-| **Latency** | Excellent for Spark and ML; BI requires external tools (Power BI, Tableau) |
-| **Compliance** | Unity Catalog provides fine-grained access; FedRAMP available on Azure |
+| **Cost** | Consumption-based pricing; GPU clusters can be expensive; separate BI tooling cost |
+| **Latency** | Excellent for Spark and ML; BI typically requires external tools such as Power BI |
+| **Compliance** | The platform's catalog provides fine-grained access; FedRAMP available on Azure |
 | **Skill match** | Strong for Spark/Python/ML engineers; less natural for T-SQL/Power BI teams |
 
 ### Anti-patterns
 
-- Using Databricks as a BI platform (no native dashboarding equivalent to Power BI + Direct Lake)
-- Running Databricks on Azure solely for Spark when Fabric Lakehouse provides equivalent compute
-- Ignoring OneLake interoperability -- Databricks can read/write OneLake via ABFS shortcuts
-- Maintaining separate Databricks and Fabric environments without Delta Sharing or shortcut integration
+- Using a Spark/ML-first competitor as a BI platform when it lacks native dashboarding equivalent to Power BI + Direct Lake
+- Running the competitor's platform on Azure solely for Spark when Fabric Lakehouse provides equivalent compute
+- Ignoring OneLake interoperability -- many competitor platforms can read/write OneLake via ABFS shortcuts
+- Maintaining separate competitor and Fabric environments without open data-sharing or shortcut integration
 
 ---
 
@@ -189,15 +192,15 @@ flowchart TD
 
 ## Quick Comparison
 
-| Dimension | Fabric | Databricks | Synapse |
+| Dimension | Fabric | Lakehouse/ML Competitor | Synapse |
 |-----------|--------|------------|---------|
-| **Model** | SaaS (capacity) | PaaS (DBU) | PaaS (DWU/vCore) |
-| **BI** | Power BI (native) | External (Power BI, Tableau) | External |
-| **ML/AI** | AutoML, notebooks | MLflow, GPU, Feature Store | Spark ML |
+| **Model** | SaaS (capacity) | PaaS (consumption units) | PaaS (DWU/vCore) |
+| **BI** | Power BI (native) | External (e.g., Power BI) | External |
+| **ML/AI** | AutoML, notebooks | Experiment tracking, GPU, feature store | Spark ML |
 | **Real-Time** | Eventstream, Eventhouse | Structured Streaming | N/A |
-| **Governance** | Purview | Unity Catalog | Purview |
-| **Multi-Cloud** | Azure only | AWS, GCP, Azure | Azure only |
-| **Storage** | OneLake (Delta) | DBFS / Unity Catalog (Delta) | ADLS Gen2 |
+| **Governance** | Purview | Platform-native catalog | Purview |
+| **Multi-Cloud** | Azure only | Multiple cloud providers | Azure only |
+| **Storage** | OneLake (Delta) | Platform storage / catalog (Delta) | ADLS Gen2 |
 | **Future** | Active development | Active development | Maintenance mode |
 
 ---

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -19,6 +19,9 @@ hero_alt: Decisions — Architecture trade-offs and ADRs
 
 **Last Updated:** `2026-05-05` | **Version:** 1.0.0
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## When to Use These Guides
@@ -55,7 +58,7 @@ These interactive decision trees help you navigate the most common "which should
 
     [:octicons-arrow-right-24: Navigate decision tree](direct-lake-import-directquery.md)
 
--   **[Fabric vs Databricks vs Synapse](fabric-databricks-synapse.md)**
+-   **[Fabric vs. competing analytics platforms](fabric-databricks-synapse.md)**
 
     ---
 

--- a/docs/decisions/lakehouse-warehouse-sqldb.md
+++ b/docs/decisions/lakehouse-warehouse-sqldb.md
@@ -19,6 +19,9 @@ type: decision
 
 **Last Updated:** `2026-05-05` | **Version:** 1.0.0
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## TL;DR
@@ -30,7 +33,7 @@ Use **Lakehouse** when your team writes PySpark and needs schema-on-read flexibi
 ## When This Question Comes Up
 
 - Starting a new Fabric project and choosing the primary data store
-- Migrating an existing SQL Server, Synapse, or Databricks workload to Fabric
+- Migrating an existing SQL Server, Synapse, or competing-platform workload to Fabric
 - A team with mixed T-SQL and PySpark skills needs to pick a default engine
 - You need to expose data to Power BI via Direct Lake and must decide where Delta tables live
 - An application requires both analytical queries and operational transactions

--- a/docs/features/copy-job-cdc.md
+++ b/docs/features/copy-job-cdc.md
@@ -21,6 +21,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 Copy Job is a Microsoft Fabric workspace item (Preview) designed for **continuous, low-code data ingestion with built-in change data capture (CDC)**. It fills a critical gap in the Fabric data movement spectrum -- between the one-shot Copy Activity (which runs once per pipeline execution) and database Mirroring (which provides full real-time replication). Copy Job provides a middle ground: **scheduled incremental ingestion** that automatically tracks what has changed since the last run and loads only the delta.

--- a/docs/features/database-hub.md
+++ b/docs/features/database-hub.md
@@ -21,6 +21,11 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 > ⚠️ **Early Access Notice**: Database Hub is currently in **Early Access** (announced March 2026). Features, UI, and capabilities may change significantly before general availability. Do not use for production-critical workflows. Early Access requires opt-in via Fabric Admin portal.
 
 ---

--- a/docs/features/dataflow-gen2.md
+++ b/docs/features/dataflow-gen2.md
@@ -21,6 +21,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 Dataflow Gen2 is Microsoft Fabric's **low-code, visual ETL engine** built on Power Query Online. It lets analysts and engineers author data transformations using the same Power Query M language familiar from Power BI Desktop and Excel — but with enterprise-grade execution, direct output to Fabric destinations (Lakehouse, Warehouse, SQL Database), and integration with Data Factory pipelines.

--- a/docs/features/dbt-fabric-integration.md
+++ b/docs/features/dbt-fabric-integration.md
@@ -21,6 +21,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 The **dbt Job in Fabric Data Factory** (Preview, announced at Microsoft Ignite 2025) brings the dbt (data build tool) transformation framework natively into the Microsoft Fabric ecosystem. Teams can now author, schedule, and monitor dbt projects directly within Data Factory without provisioning external compute or managing separate orchestration infrastructure.

--- a/docs/features/eval-harness-llm.md
+++ b/docs/features/eval-harness-llm.md
@@ -22,6 +22,11 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 Evaluating large language model (LLM) workloads is fundamentally harder than evaluating classical ML systems. Three properties make traditional evaluation approaches insufficient:

--- a/docs/features/federated-fabric-gcc.md
+++ b/docs/features/federated-fabric-gcc.md
@@ -21,6 +21,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Overview
 
 As of April 2026, **Microsoft Fabric is not available in Office 365 GCC, GCC High, or DoD environments**. Microsoft has not published a firm GA date, though industry sources expect Fabric to land in Azure Government by late 2026. This leaves government organizations — state, local, tribal, and federal agencies in GCC — without access to Fabric's unified analytics platform while their commercial counterparts adopt it rapidly.

--- a/docs/features/mirroring.md
+++ b/docs/features/mirroring.md
@@ -22,6 +22,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 Mirroring in Microsoft Fabric provides near-real-time replication of external databases into OneLake as Delta Lake tables. Instead of building complex ETL pipelines to extract, transform, and load data from operational systems, Mirroring captures changes at the source database level and continuously applies them to a mirrored Lakehouse or Warehouse in Fabric.

--- a/docs/features/onelake-catalog.md
+++ b/docs/features/onelake-catalog.md
@@ -21,6 +21,11 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 OneLake Catalog is Microsoft Fabric's unified data discovery hub that provides a centralized experience for browsing, searching, tagging, endorsing, and governing all items across your Fabric estate. Available as a **Generally Available** feature, OneLake Catalog replaces the fragmented experience of navigating between workspaces, Lakehouses, Warehouses, and semantic models to find the right dataset -- instead offering a single searchable catalog that spans the entire organization's Fabric footprint.

--- a/docs/features/onelake-iceberg-interop.md
+++ b/docs/features/onelake-iceberg-interop.md
@@ -21,6 +21,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 OneLake now supports **Apache Iceberg format** alongside Delta Lake as a Generally Available feature (February 2026). Delta tables stored in OneLake can be **virtualized as Iceberg** without any data movement or duplication, enabling external compute engines to read Fabric-managed data through the industry-standard Iceberg protocol. Snowflake **bidirectional interoperability** reached GA simultaneously, allowing Snowflake to write Iceberg tables directly into OneLake and Fabric to read Snowflake-managed Iceberg data via shortcuts.

--- a/docs/features/onelake-shortcuts-s3-gcs-dataverse.md
+++ b/docs/features/onelake-shortcuts-s3-gcs-dataverse.md
@@ -21,6 +21,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Overview
 
 OneLake shortcuts are symbolic links that make data stored in external locations appear as if it lives natively in a Fabric Lakehouse. They enable data federation across cloud providers and storage systems without physically copying data, reducing storage costs and eliminating ETL latency for read-heavy scenarios.

--- a/docs/features/rag-patterns-deep-dive.md
+++ b/docs/features/rag-patterns-deep-dive.md
@@ -22,6 +22,11 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 Retrieval-Augmented Generation (RAG) grounds an LLM's response in a curated corpus of your own documents. Instead of relying solely on the model's parametric knowledge, RAG **retrieves** relevant passages from a vector store at query time and **augments** the prompt with that context, letting the model **generate** an answer that cites real sources. RAG is the dominant pattern for enterprise AI assistants because it produces fewer hallucinations, supports citations, respects access control, and stays current as documents change — all without retraining the model.
@@ -129,7 +134,7 @@ Pure vector search misses **lexical matches** — exact identifiers, codes, acro
 
 ### Eventhouse as the Primary Store
 
-Eventhouse with Vector16 encoding is our default vector store: it co-locates structured filters (date, doc type, tenant) with vector similarity in a single KQL query, eliminating the cross-system joins that plague Pinecone/Weaviate setups. See [Eventhouse Vector Database](eventhouse-vector-database.md) for the storage primitives.
+Eventhouse with Vector16 encoding is our default vector store on Fabric because it co-locates structured filters (date, doc type, tenant) with vector similarity in a single KQL query, avoiding the cross-system joins that arise when a standalone, external vector database sits alongside the analytics store. Dedicated vector databases remain a strong choice in many architectures — pick the store that best fits your stack. See [Eventhouse Vector Database](eventhouse-vector-database.md) for the storage primitives.
 
 ---
 

--- a/docs/features/real-time-hub.md
+++ b/docs/features/real-time-hub.md
@@ -21,6 +21,11 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 Real-Time Hub is a **centralized event catalog** in Microsoft Fabric that makes all streaming data discoverable, shareable, and consumable across the organization. Instead of creating point-to-point Eventstream connections, teams publish events to the Real-Time Hub where other teams can browse, subscribe, and build derived streams.

--- a/docs/features/real-time-intelligence.md
+++ b/docs/features/real-time-intelligence.md
@@ -22,6 +22,11 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 Real-Time Intelligence (RTI) in Microsoft Fabric provides a complete streaming analytics platform that enables organizations to ingest, process, analyze, and act on data in motion. RTI brings together four key components -- Eventstreams, Eventhouse, Real-Time Dashboards, and Data Activator -- into a unified experience within the Fabric workspace.

--- a/docs/features/spark-environments-job-definitions.md
+++ b/docs/features/spark-environments-job-definitions.md
@@ -21,6 +21,11 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎯 Overview
 
 **Fabric Environments** and **Spark Job Definitions** are two complementary features for production Spark workloads:
@@ -170,7 +175,7 @@ spark.databricks.delta.properties.defaults.enableChangeDataFeed=true
 
 ### What Is a Spark Job Definition?
 
-A Spark Job Definition (SJD) runs a PySpark `.py` script as a batch job — no notebook UI, no interactive cells. It's the Fabric equivalent of submitting a Spark job in Databricks Jobs or Synapse Spark pools.
+A Spark Job Definition (SJD) runs a PySpark `.py` script as a batch job — no notebook UI, no interactive cells. It plays a similar role to headless Spark batch submission on other Spark platforms, or to Azure Synapse Spark pools.
 
 ### When to Use SJD vs. Notebook
 

--- a/docs/features/vnet-data-gateway.md
+++ b/docs/features/vnet-data-gateway.md
@@ -21,6 +21,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 The VNet Data Gateway is a Microsoft-managed gateway that runs inside a customer's Azure Virtual Network (VNet), enabling Fabric to securely connect to data sources that are not publicly accessible. Unlike the traditional on-premises data gateway — which requires installing and maintaining software on a dedicated VM — the VNet Data Gateway is a fully managed Azure resource that inherits the network security posture of your VNet.

--- a/docs/industries/healthcare.md
+++ b/docs/industries/healthcare.md
@@ -26,6 +26,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Scenario Overview
 
 | Scenario | Fabric Pattern | Latency Target | Key Features |

--- a/docs/industries/manufacturing.md
+++ b/docs/industries/manufacturing.md
@@ -26,6 +26,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Scenario Overview
 
 | Scenario | Fabric Pattern | Latency Target | Key Features |

--- a/docs/microsoft-fabric-features-april-2026.md
+++ b/docs/microsoft-fabric-features-april-2026.md
@@ -17,6 +17,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🔧 1. Data Engineering
 
 ### Spark Runtime & Compute

--- a/docs/research/ai-readiness-assessment.md
+++ b/docs/research/ai-readiness-assessment.md
@@ -7,6 +7,9 @@ type: deep-dive
 
 > A structured framework for evaluating an organization's readiness to adopt Fabric AI capabilities — Copilot, AutoML, Semantic Link, Data Agents, and AI Functions — with a maturity model, assessment questionnaire, and implementation roadmap.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Executive Summary
 
 Microsoft Fabric's AI capabilities span a broad spectrum, from no-code Copilot assistance to advanced Data Agents that autonomously orchestrate multi-step analytics workflows. However, organizations cannot simply "turn on AI" — successful adoption requires foundational maturity in data quality, governance, infrastructure, skills, and organizational culture. This assessment framework helps enterprise leaders evaluate where they stand today and chart a realistic path to AI-powered analytics.

--- a/docs/research/data-mesh-maturity-model.md
+++ b/docs/research/data-mesh-maturity-model.md
@@ -7,6 +7,9 @@ type: deep-dive
 
 > How to implement Data Mesh principles using Fabric constructs — workspaces as domains, OneLake as federated storage, Purview as the governance plane, and data products delivered via lakehouses and semantic models. Includes maturity levels, assessment criteria, and a migration path from centralized to mesh.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Executive Summary
 
 Data Mesh is an organizational and architectural paradigm that treats data as a product, owned and operated by the business domains that produce it, rather than centrally managed by a monolithic data team. The four pillars of Data Mesh — domain-oriented ownership, data as a product, self-serve data infrastructure, and federated computational governance — map naturally onto Microsoft Fabric's architecture, but successful implementation requires deliberate organizational change alongside technical configuration.

--- a/docs/research/enterprise-data-platform-comparison.md
+++ b/docs/research/enterprise-data-platform-comparison.md
@@ -5,11 +5,22 @@ type: deep-dive
 ---
 # Enterprise Data Platform Comparison 2026
 
-> Fabric vs Databricks vs Snowflake vs Synapse Analytics — a structured comparison to guide platform selection for enterprise analytics, data engineering, and AI workloads.
+> Microsoft Fabric compared against leading competitor platforms and Azure Synapse Analytics — a structured comparison to guide platform selection for enterprise analytics, data engineering, and AI workloads.
+
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+!!! abstract "Competitor legend"
+    To compare distinct non-Microsoft platforms without naming them, this page uses neutral labels:
+
+    - **Competitor A (lakehouse / ML platform)** — a Spark- and MLOps-oriented lakehouse platform available across multiple clouds.
+    - **Competitor B (multi-cloud cloud data warehouse)** — a SaaS, separation-of-storage-and-compute data warehouse available across multiple clouds.
+
+    These labels are not mapped back to specific vendor names. Microsoft, Azure, and open-source names (Microsoft Fabric, OneLake, Power BI, Purview, Azure Synapse, SQL Server, Spark, Delta Lake, Apache Iceberg, Parquet, Kafka, etc.) are kept as-is.
 
 ## Executive Summary
 
-Organizations evaluating enterprise data platforms in 2026 face a market with four dominant contenders: Microsoft Fabric, Databricks, Snowflake, and Azure Synapse Analytics. Each platform has matured significantly, but they approach the problem from fundamentally different architectural philosophies. Fabric unifies compute, storage, governance, and BI into a single SaaS experience anchored on OneLake. Databricks leads in open-source Spark engineering and MLOps. Snowflake excels at multi-cloud data sharing and governed SQL analytics. Synapse Analytics, while still supported, has been largely superseded by Fabric for new deployments in the Microsoft ecosystem.
+Organizations evaluating enterprise data platforms in 2026 face a market with several dominant contenders: Microsoft Fabric, two leading competitor platforms (referred to here as Competitor A and Competitor B), and Azure Synapse Analytics. Each platform has matured significantly, but they approach the problem from fundamentally different architectural philosophies. Fabric unifies compute, storage, governance, and BI into a single SaaS experience anchored on OneLake. Per publicly available documentation, Competitor A (a lakehouse / ML platform) emphasizes open-source Spark engineering and MLOps, while Competitor B (a multi-cloud cloud data warehouse) emphasizes multi-cloud data sharing and governed SQL analytics. Synapse Analytics, while still supported, has been largely superseded by Fabric for new deployments in the Microsoft ecosystem.
 
 This paper provides a structured comparison across ten dimensions — architecture, compute, storage, governance, BI integration, AI/ML capabilities, real-time analytics, cost model, ecosystem maturity, and migration complexity — to help enterprise architects and CDOs make informed platform decisions.
 
@@ -21,8 +32,8 @@ The following framework evaluates each platform across dimensions that matter mo
 flowchart TD
     A[Platform Selection] --> B{Primary Workload?}
     B -->|Unified Analytics + BI| C[Microsoft Fabric]
-    B -->|Advanced ML/MLOps| D[Databricks]
-    B -->|Multi-Cloud SQL Analytics| E[Snowflake]
+    B -->|Advanced ML/MLOps| D["Competitor A (Lakehouse/ML)"]
+    B -->|Multi-Cloud SQL Analytics| E["Competitor B (Cloud DW)"]
     B -->|Legacy Synapse Investment| F[Azure Synapse]
 
     C --> G{Decision Factors}
@@ -47,17 +58,17 @@ Fabric is a unified SaaS analytics platform built on OneLake, a single-copy data
 
 The architectural bet is on convergence: rather than best-of-breed tools stitched together via ETL, Fabric provides a "good enough at everything, excellent at integration" experience. This is most compelling for organizations that are already invested in the Microsoft ecosystem (Azure, Power BI, Microsoft 365, Purview) and want to reduce operational complexity.
 
-### Databricks
+### Competitor A (Lakehouse / ML Platform)
 
-Databricks is built on Apache Spark and the Lakehouse architecture, combining the flexibility of data lakes with the reliability of data warehouses. The platform centers on the Unity Catalog for governance, Delta Lake for ACID transactions, and a highly optimized Photon SQL engine for warehouse-style queries. Databricks runs on all three major clouds (Azure, AWS, GCP) and offers the deepest integration with open-source data engineering and ML tools (MLflow, Feature Store, Model Serving).
+Per publicly available documentation, Competitor A is built on Apache Spark and a lakehouse architecture, combining the flexibility of data lakes with the reliability of data warehouses. The platform centers on its own catalog for governance, Delta Lake for ACID transactions, and a vectorized SQL engine for warehouse-style queries. It runs on all three major public clouds and offers deep integration with open-source data engineering and ML tools (Spark, MLflow, feature store, and model serving).
 
-The architectural bet is on openness and performance: Databricks gives engineering teams maximum control over compute configuration, cluster sizing, and runtime behavior, at the cost of higher operational complexity. Organizations with strong data engineering teams and advanced ML/AI workloads often find Databricks' flexibility worth the overhead.
+The architectural emphasis is on openness and performance: the platform gives engineering teams substantial control over compute configuration, cluster sizing, and runtime behavior, at the cost of higher operational complexity. Organizations with strong data engineering teams and advanced ML/AI workloads often find this flexibility worth the overhead — and for engineering-heavy, deep-ML use cases this is frequently the stronger choice.
 
-### Snowflake
+### Competitor B (Multi-Cloud Cloud Data Warehouse)
 
-Snowflake is a cloud-native data warehouse built on a separation of storage and compute architecture. Each workload runs in its own virtual warehouse (compute cluster), and all data is stored in a proprietary columnar format. Snowflake's differentiators are its zero-management compute scaling, cross-cloud data sharing via Snowflake Marketplace, and its Snowpark developer experience for Python/Java/Scala workloads. The platform has expanded into streaming (Snowpipe Streaming), ML (Snowpark ML, Cortex), and application development (Streamlit, Native Apps).
+Per publicly available documentation, Competitor B is a cloud-native data warehouse built on a separation-of-storage-and-compute architecture. Each workload runs in its own virtual warehouse (compute cluster), and data is stored in a proprietary columnar format. Its documented differentiators are zero-management compute scaling, cross-cloud data sharing via a built-in marketplace, and a developer experience for Python/Java/Scala workloads. The platform has expanded into streaming, ML, and application development capabilities.
 
-The architectural bet is on simplicity and portability: Snowflake abstracts away infrastructure management almost entirely and provides the most frictionless multi-cloud experience. Organizations that need governed SQL analytics across AWS, Azure, and GCP without cloud lock-in often gravitate toward Snowflake.
+The architectural emphasis is on simplicity and portability: the platform abstracts away most infrastructure management and provides a frictionless multi-cloud experience. Organizations that need governed SQL analytics across multiple clouds without single-cloud lock-in often gravitate toward this kind of offering, and for that requirement it is frequently the stronger choice.
 
 ### Azure Synapse Analytics
 
@@ -67,22 +78,24 @@ The architectural bet was on Azure-native integration, but the multi-service mod
 
 ## 2. Feature Matrix
 
-| Capability | Fabric | Databricks | Snowflake | Synapse |
+The non-Microsoft columns reflect each vendor's publicly available documentation; verify against current vendor docs.
+
+| Capability | Fabric | Competitor A (Lakehouse/ML) | Competitor B (Cloud DW) | Synapse |
 |-----------|--------|------------|-----------|---------|
 | **Unified storage** | OneLake (Delta Parquet) | Delta Lake (open) | Proprietary columnar | ADLS Gen2 + SQL pools |
-| **SQL analytics** | Warehouse (T-SQL) | Databricks SQL (ANSI) | Snowflake SQL (ANSI) | Dedicated/Serverless SQL |
-| **Spark processing** | Spark via Notebooks | Optimized Spark + Photon | Snowpark (Spark-like) | Spark pools |
-| **Real-time ingestion** | Eventstream + Eventhouse | Delta Live Tables + Structured Streaming | Snowpipe Streaming | Event Hubs integration |
+| **SQL analytics** | Warehouse (T-SQL) | ANSI SQL engine | ANSI SQL engine | Dedicated/Serverless SQL |
+| **Spark processing** | Spark via Notebooks | Optimized Spark + vectorized engine | Spark-like dataframe API | Spark pools |
+| **Real-time ingestion** | Eventstream + Eventhouse | Declarative pipelines + Structured Streaming | Native streaming ingestion | Event Hubs integration |
 | **BI integration** | Direct Lake (native) | Partner BI via JDBC/ODBC | Partner BI via JDBC/ODBC | Power BI via DirectQuery |
-| **Governance** | Purview (built-in) | Unity Catalog | Horizon (governance) | Purview (add-on) |
-| **AI/ML** | AutoML, Copilot, Data Agents, AI Functions | MLflow, Feature Store, Model Serving, Mosaic | Cortex, Snowpark ML | Azure ML integration |
-| **Data sharing** | Shortcuts, Mirroring | Delta Sharing (open protocol) | Snowflake Marketplace | Linked services |
-| **Multi-cloud** | Azure only | Azure, AWS, GCP | Azure, AWS, GCP | Azure only |
-| **CI/CD** | fabric-cicd, Git integration | Databricks Asset Bundles, Repos | Schemachange, Terraform | ARM/Bicep, Synapse Git |
-| **Cost model** | Capacity Units (CU) — shared pool | DBU — per-cluster billing | Credits — per-warehouse billing | DWU + vCore — per-pool billing |
-| **Iceberg support** | Read via shortcuts + mirroring | Read/write via UniForm | Native Iceberg tables | Limited |
+| **Governance** | Purview (built-in) | Built-in catalog | Built-in governance suite | Purview (add-on) |
+| **AI/ML** | AutoML, Copilot, Data Agents, AI Functions | MLflow, feature store, model serving | Built-in LLM and ML services | Azure ML integration |
+| **Data sharing** | Shortcuts, Mirroring | Open sharing protocol | Built-in data marketplace | Linked services |
+| **Multi-cloud** | Azure only | Multi-cloud | Multi-cloud | Azure only |
+| **CI/CD** | fabric-cicd, Git integration | Asset bundles, Git repos | Migration tooling, Terraform | ARM/Bicep, Synapse Git |
+| **Cost model** | Capacity Units (CU) — shared pool | Per-cluster compute-unit billing | Per-warehouse credit billing | DWU + vCore — per-pool billing |
+| **Iceberg support** | Read via shortcuts + mirroring | Read/write via open table interop | Native Iceberg tables | Limited |
 | **Digital twin** | Digital Twin Builder (preview) | Partner solutions | Not available | Not available |
-| **Copilot/AI assist** | Fabric Copilot (native) | Databricks Assistant | Snowflake Cortex | Limited |
+| **Copilot/AI assist** | Fabric Copilot (native) | Built-in assistant | Built-in AI services | Limited |
 
 ## 3. Total Cost of Ownership Analysis
 
@@ -90,22 +103,24 @@ TCO comparisons between platforms are notoriously difficult because pricing mode
 
 ### Cost Categories
 
-**Compute costs** represent the largest portion of TCO for all platforms. Fabric uses a shared CU pool where all workloads draw from the same capacity, which can lead to efficient utilization but also contention. Databricks bills per DBU per cluster, giving precise cost attribution but requiring active cluster management. Snowflake bills per credit per virtual warehouse, with automatic suspend/resume reducing idle costs. Synapse bills per DWU for dedicated pools and per query for serverless.
+**Compute costs** represent the largest portion of TCO for all platforms. Fabric uses a shared CU pool where all workloads draw from the same capacity, which can lead to efficient utilization but also contention. Per publicly available documentation, Competitor A bills per compute-unit per cluster, giving precise cost attribution but requiring active cluster management; Competitor B bills per credit per virtual warehouse, with automatic suspend/resume reducing idle costs. Synapse bills per DWU for dedicated pools and per query for serverless.
 
-**Storage costs** are relatively similar across platforms when using cloud-native object storage (ADLS, S3, GCS). Fabric's OneLake eliminates duplication costs by storing data once. Snowflake's proprietary storage adds a small premium. Databricks and Synapse use open formats on cloud storage.
+**Storage costs** are relatively similar across platforms when using cloud-native object storage. Fabric's OneLake eliminates duplication costs by storing data once. Per publicly available documentation, Competitor B's proprietary storage carries a small premium; Competitor A and Synapse use open formats on cloud storage.
 
-**Governance and security costs** are often hidden. Fabric includes Purview integration at no additional cost. Databricks Unity Catalog is included in Premium/Enterprise tiers. Snowflake Horizon is included. Synapse requires separate Purview licensing.
+**Governance and security costs** are often hidden. Fabric includes Purview integration at no additional cost. Per publicly available documentation, the competitor platforms include their respective governance suites within their premium/enterprise tiers. Synapse requires separate Purview licensing.
 
-**Operational costs** — the human effort to manage, monitor, and troubleshoot the platform — vary significantly. Fabric and Snowflake minimize operational overhead through SaaS automation. Databricks requires more engineering effort for cluster management, job scheduling, and cost optimization. Synapse sits in between.
+**Operational costs** — the human effort to manage, monitor, and troubleshoot the platform — vary significantly. Fabric and Competitor B minimize operational overhead through SaaS automation. Competitor A requires more engineering effort for cluster management, job scheduling, and cost optimization. Synapse sits in between.
 
 ### Normalized TCO Comparison (Illustrative)
 
-| Cost Component | Fabric (F64) | Databricks (Premium) | Snowflake (Enterprise) | Synapse (Dedicated) |
+Competitor figures are illustrative estimates derived from publicly available pricing documentation, not the author's expert assessment; verify against current vendor pricing.
+
+| Cost Component | Fabric (F64) | Competitor A (Premium tier) | Competitor B (Enterprise tier) | Synapse (Dedicated) |
 |---------------|-------------|---------------------|----------------------|-------------------|
 | Compute (annual) | ~$105K (F64 PAYG) | ~$120-180K (varies by cluster) | ~$100-160K (varies by warehouse) | ~$90-150K (varies by DWU) |
-| Storage (10 TB) | ~$2.4K (ADLS rates) | ~$2.4K (ADLS/S3 rates) | ~$4.6K (Snowflake storage) | ~$2.4K (ADLS rates) |
-| Governance | Included (Purview) | Included (Unity Catalog) | Included (Horizon) | +$12-24K (Purview) |
-| BI tooling | Included (Power BI) | +$12-120K (Tableau/Power BI) | +$12-120K (Tableau/Power BI) | +$12-120K (Power BI Pro/Premium) |
+| Storage (10 TB) | ~$2.4K (ADLS rates) | ~$2.4K (cloud object storage rates) | ~$4.6K (proprietary storage) | ~$2.4K (ADLS rates) |
+| Governance | Included (Purview) | Included (built-in catalog) | Included (built-in governance) | +$12-24K (Purview) |
+| BI tooling | Included (Power BI) | +$12-120K (partner BI / Power BI) | +$12-120K (partner BI / Power BI) | +$12-120K (Power BI Pro/Premium) |
 | Ops FTE (partial) | 0.25-0.5 FTE | 0.5-1.0 FTE | 0.25-0.5 FTE | 0.5-0.75 FTE |
 | **Estimated 3-yr TCO** | **$350-450K** | **$500-700K** | **$400-600K** | **$400-550K** |
 
@@ -117,13 +132,15 @@ Fabric's cost advantage is strongest when an organization already has Microsoft 
 
 ### When Fabric Loses on Cost
 
-Fabric's cost advantage diminishes for organizations that run heavy, sustained Spark workloads (where Databricks' Photon engine delivers better price/performance), need multi-cloud deployment (where Snowflake's portability avoids cloud lock-in premiums), or have existing Databricks/Snowflake investments that would require costly migration to abandon.
+Fabric's cost advantage diminishes for organizations that run heavy, sustained Spark workloads (where Competitor A's vectorized engine is documented to deliver strong price/performance), need multi-cloud deployment (where Competitor B's portability avoids cloud lock-in premiums), or have existing investments in a competitor platform that would require costly migration to abandon. In those scenarios the referenced competitor offering may well be the stronger choice.
 
 ## 4. Maturity Assessment
 
 Platform maturity spans technical capability, ecosystem breadth, community size, and enterprise adoption. The following assessment uses a five-level maturity model.
 
-| Dimension | Fabric | Databricks | Snowflake | Synapse |
+Competitor maturity ratings are this project's directional reading of publicly available information, offered in good faith; they are not an authoritative or expert ranking of any third-party product.
+
+| Dimension | Fabric | Competitor A (Lakehouse/ML) | Competitor B (Cloud DW) | Synapse |
 |-----------|--------|------------|-----------|---------|
 | SQL analytics | Level 4 (Mature) | Level 4 (Mature) | Level 5 (Leader) | Level 4 (Mature) |
 | Spark/data engineering | Level 3 (Established) | Level 5 (Leader) | Level 3 (Established) | Level 3 (Established) |
@@ -152,11 +169,11 @@ Organizations migrating to Fabric typically come from one of four starting point
 
 **From Synapse Analytics:** The most straightforward migration path. Fabric's Warehouse uses the same T-SQL engine as Synapse dedicated pools. Pipelines migrate with minimal changes. Spark notebooks require replacing `%%configure` with Fabric's Spark session configuration. Microsoft provides workspace migration tooling. See the [migration patterns](../best-practices/migration-patterns.md) guide.
 
-**From Databricks:** Requires rewriting Spark notebooks to replace Databricks-specific APIs (dbutils, Databricks widgets, Unity Catalog references) with Fabric equivalents (mssparkutils, Fabric notebook parameters, Purview). Delta Lake tables can be accessed via OneLake shortcuts without data movement. MLflow models need to be re-registered in Fabric's ML model registry.
+**From Competitor A (lakehouse / ML platform):** Per publicly available documentation, this requires rewriting Spark notebooks to replace platform-specific APIs (utility libraries, widgets, and catalog references) with Fabric equivalents (mssparkutils, Fabric notebook parameters, Purview). Delta Lake tables can be accessed via OneLake shortcuts without data movement. MLflow models need to be re-registered in Fabric's ML model registry.
 
-**From Snowflake:** Requires the most architectural change since Snowflake's proprietary storage format doesn't directly translate to Delta Parquet. Data must be exported and re-ingested. SQL stored procedures need rewriting from Snowflake's JavaScript UDFs to Fabric's T-SQL or Spark equivalents. Snowpipe integrations need replacement with Fabric Eventstreams or Pipelines.
+**From Competitor B (multi-cloud cloud data warehouse):** Per publicly available documentation, this requires the most architectural change since the platform's proprietary storage format doesn't directly translate to Delta Parquet. Data must be exported and re-ingested. SQL stored procedures need rewriting from the platform's UDF dialect to Fabric's T-SQL or Spark equivalents. Native streaming-ingestion integrations need replacement with Fabric Eventstreams or Pipelines.
 
-**From on-premises (SQL Server, Oracle, Teradata):** Fabric provides Mirroring for near-real-time replication from SQL Server and Azure SQL Database. For other sources, use Data Factory pipelines with on-premises data gateway. The [migration tutorial](../tutorials/10-teradata-migration/README.md) covers Teradata-specific patterns.
+**From on-premises systems (SQL Server and other relational/MPP databases):** Fabric provides Mirroring for near-real-time replication from SQL Server and Azure SQL Database. For other sources, use Data Factory pipelines with on-premises data gateway. The [migration tutorial](../tutorials/10-teradata-migration/README.md) covers patterns for legacy MPP warehouse sources.
 
 ### Migration Risk Assessment
 
@@ -180,20 +197,20 @@ Organizations migrating to Fabric typically come from one of four starting point
 - You need integrated real-time analytics with minimal infrastructure management
 - Budget consolidation across analytics services is a goal
 
-### Choose Databricks When
+### Choose Competitor A (Lakehouse / ML Platform) When
 
 - You have a strong data engineering team comfortable with Spark and cluster management
 - Advanced ML/MLOps workloads (model training, feature stores, model serving) are central to your strategy
 - You need multi-cloud deployment flexibility
 - Open-source alignment and community-driven innovation are important
 - You need maximum control over compute performance tuning
-- Your organization has existing Databricks investments and expertise
+- Your organization has existing investments and expertise in that platform
 
-### Choose Snowflake When
+### Choose Competitor B (Multi-Cloud Cloud Data Warehouse) When
 
-- Multi-cloud data sharing (across AWS, Azure, GCP) is a hard requirement
+- Multi-cloud data sharing across several public clouds is a hard requirement
 - You need the simplest possible operational model for SQL analytics
-- Data marketplace and governed data sharing are core to your strategy
+- A data marketplace and governed data sharing are core to your strategy
 - Your workload is predominantly SQL-based with modest Spark requirements
 - You prioritize cross-cloud portability over deep ecosystem integration with any single cloud
 - Your BI strategy is multi-vendor (not exclusively Power BI)
@@ -219,20 +236,20 @@ flowchart LR
         OL --> PV[Purview Governance]
     end
 
-    subgraph DBX["Databricks"]
+    subgraph DBX["Competitor A (Lakehouse/ML)"]
         direction TB
         DLK[Delta Lake] --> SP[Spark Clusters]
-        DLK --> DBSQL[Databricks SQL]
-        SP --> MLF[MLflow]
-        DLK --> UC[Unity Catalog]
+        DLK --> DBSQL[SQL Engine]
+        SP --> MLF[MLflow / Model Serving]
+        DLK --> UC[Built-in Catalog]
     end
 
-    subgraph SF["Snowflake"]
+    subgraph SF["Competitor B (Cloud DW)"]
         direction TB
-        SS[Snowflake Storage] --> VW[Virtual Warehouses]
-        SS --> SPK[Snowpark]
-        VW --> MKT[Marketplace]
-        SS --> HZ[Horizon]
+        SS[Proprietary Storage] --> VW[Virtual Warehouses]
+        SS --> SPK[Dataframe API]
+        VW --> MKT[Data Marketplace]
+        SS --> HZ[Built-in Governance]
     end
 ```
 
@@ -242,17 +259,17 @@ Real-time analytics has become a critical differentiator as organizations move f
 
 **Fabric** provides a fully integrated real-time pipeline: Eventstream ingests data from Azure Event Hubs, Kafka, and custom sources; Eventhouse (powered by Azure Data Explorer / KQL engine) provides sub-second query performance on streaming data; Real-Time Dashboards render live visualizations; and Data Activator triggers automated actions based on conditions in the stream. The advantage is tight integration — from ingestion to alerting in a single platform. The limitation is that Eventstream throughput is bounded by the Fabric capacity SKU.
 
-**Databricks** offers Structured Streaming and Delta Live Tables for stream processing within the Spark ecosystem. DLT provides declarative pipeline definitions with automatic data quality enforcement (expectations). Databricks excels at complex stream processing logic but requires separate infrastructure for dashboarding (typically pushing to a partner BI tool) and alerting (typically through third-party monitoring).
+**Competitor A (lakehouse / ML platform)** offers, per publicly available documentation, Structured Streaming and declarative streaming pipelines for stream processing within the Spark ecosystem, with automatic data quality enforcement (expectations). The platform is well-suited to complex stream processing logic but typically relies on separate infrastructure for dashboarding (pushing to a partner BI tool) and alerting (through third-party monitoring).
 
-**Snowflake** introduced Snowpipe Streaming for low-latency data loading and Dynamic Tables for incremental materialization. While improving rapidly, Snowflake's streaming capabilities are less mature than Fabric's Eventhouse or Databricks' Structured Streaming for complex event processing. Snowflake's strength is simplifying the transition from batch to near-real-time without requiring new skill sets.
+**Competitor B (multi-cloud cloud data warehouse)** offers, per publicly available documentation, low-latency streaming ingestion and incrementally materialized tables. Its published streaming capabilities are oriented toward simplifying the transition from batch to near-real-time without requiring new skill sets, rather than toward complex event processing.
 
 **Synapse** offers Event Hubs integration and Spark Structured Streaming via Spark pools, but lacks the integrated real-time dashboard and alerting capabilities that Fabric provides natively.
 
-| Capability | Fabric | Databricks | Snowflake | Synapse |
+| Capability | Fabric | Competitor A (Lakehouse/ML) | Competitor B (Cloud DW) | Synapse |
 |-----------|--------|------------|-----------|---------|
-| Stream ingestion | Eventstream (native) | Structured Streaming | Snowpipe Streaming | Event Hubs + Spark |
-| Stream processing | Eventhouse (KQL) | Delta Live Tables | Dynamic Tables | Spark pools |
-| Sub-second query | Yes (KQL engine) | Yes (Photon) | Limited | No |
+| Stream ingestion | Eventstream (native) | Structured Streaming | Native streaming ingestion | Event Hubs + Spark |
+| Stream processing | Eventhouse (KQL) | Declarative streaming pipelines | Incrementally materialized tables | Spark pools |
+| Sub-second query | Yes (KQL engine) | Yes (vectorized engine) | Limited | No |
 | Real-time dashboards | Built-in | Partner BI tools | Partner BI tools | Partner BI tools |
 | Automated alerts | Data Activator | Third-party | Third-party | Azure Monitor |
 | Complex event processing | KQL time-series functions | Spark windowing | Limited | Spark windowing |
@@ -261,19 +278,19 @@ Real-time analytics has become a critical differentiator as organizations move f
 
 The surrounding ecosystem — community size, partner integrations, educational resources, and marketplace offerings — significantly impacts long-term platform viability and talent availability.
 
-**Databricks** has the largest and most active open-source community, driven by its stewardship of Apache Spark, Delta Lake, MLflow, and Unity Catalog. The Databricks Community Edition provides free access for learning. Partner integrations span hundreds of tools across data ingestion, BI, ML, and governance. Talent availability is strong, particularly among data engineers with Spark experience.
+**Competitor A (lakehouse / ML platform)** has, per publicly available information, a large and active open-source community associated with its stewardship of projects such as Apache Spark, Delta Lake, and MLflow, plus a free community edition for learning. Partner integrations span many tools across data ingestion, BI, ML, and governance, and talent availability is strong, particularly among data engineers with Spark experience. For open-source-aligned, engineering-heavy organizations, this ecosystem is a genuine strength.
 
-**Snowflake** has built a massive commercial ecosystem around Snowflake Marketplace, Snowflake Native Apps, and a large partner network. The Snowflake community is heavily SQL-oriented, which makes it accessible to a broad talent pool. Snowflake's annual Summit conference and active user groups drive community engagement.
+**Competitor B (multi-cloud cloud data warehouse)** has, per publicly available information, built a large commercial ecosystem around its data marketplace, native-app framework, and a broad partner network. Its community is heavily SQL-oriented, which makes it accessible to a broad talent pool, and its annual conference and active user groups drive engagement.
 
-**Fabric** has the fastest-growing community, driven by Microsoft's investment in Fabric Community forums, Microsoft Learn training paths, and the existing Power BI community (one of the largest BI communities globally). However, the Fabric-specific ecosystem is still maturing relative to Databricks and Snowflake, particularly for third-party tool integrations. Talent availability is growing rapidly as existing Microsoft data professionals upskill to Fabric.
+**Fabric** has a fast-growing community, driven by Microsoft's investment in Fabric Community forums, Microsoft Learn training paths, and the existing Power BI community (one of the largest BI communities globally). The Fabric-specific ecosystem is still maturing relative to the more established competitor platforms, particularly for third-party tool integrations. Talent availability is growing rapidly as existing Microsoft data professionals upskill to Fabric.
 
 **Synapse** has a stable but declining community as Microsoft shifts investment to Fabric. Existing Synapse practitioners are migrating their skills to Fabric, and new entrants are choosing Fabric directly.
 
 ## 10. Conclusion
 
-There is no universally "best" enterprise data platform — the right choice depends on your organization's existing investments, team skills, workload profile, multi-cloud requirements, and strategic priorities. Fabric offers the most compelling value for Microsoft-ecosystem organizations that want unified analytics with minimal operational overhead. Databricks leads for engineering-heavy organizations with advanced ML requirements. Snowflake excels for multi-cloud SQL analytics with maximum simplicity. Synapse remains viable for existing investments but is not recommended for greenfield deployments.
+There is no universally "best" enterprise data platform — the right choice depends on your organization's existing investments, team skills, workload profile, multi-cloud requirements, and strategic priorities. Fabric offers compelling value for Microsoft-ecosystem organizations that want unified analytics with minimal operational overhead. Competitor A (lakehouse / ML platform) is frequently the stronger choice for engineering-heavy organizations with advanced ML requirements. Competitor B (multi-cloud cloud data warehouse) is frequently the stronger choice for multi-cloud SQL analytics with maximum simplicity. Synapse remains viable for existing investments but is not recommended for greenfield deployments.
 
-The most pragmatic approach for many enterprises is a hybrid strategy: use Fabric for the integrated analytics-to-BI pipeline, supplement with Databricks or Snowflake for specialized workloads that benefit from their unique strengths, and connect them via open formats (Delta Lake, Iceberg) and standard protocols (JDBC/ODBC, Delta Sharing).
+The most pragmatic approach for many enterprises is a hybrid strategy: use Fabric for the integrated analytics-to-BI pipeline, supplement with a competitor platform for specialized workloads that benefit from its particular strengths, and connect them via open formats (Delta Lake, Iceberg) and standard protocols (JDBC/ODBC, open sharing protocols).
 
 ## Related Documentation
 
@@ -281,4 +298,4 @@ The most pragmatic approach for many enterprises is a hybrid strategy: use Fabri
 - [Mirroring](../features/mirroring.md) — Real-time database replication into OneLake
 - [Migration Patterns](../best-practices/migration-patterns.md) — Enterprise migration strategies
 - [Capacity Planning & Cost Optimization](../best-practices/capacity-planning-cost-optimization.md) — Fabric CU budgeting
-- [Fabric vs Databricks vs Synapse Decision Tree](../decisions/fabric-databricks-synapse.md) — Interactive decision flowchart
+- [Fabric vs Competitor vs Synapse Decision Tree](../decisions/fabric-databricks-synapse.md) — Interactive decision flowchart

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -7,13 +7,16 @@ hero_alt: "White Papers — Research, maturity models, and platform comparisons 
 
 Strategic analysis, maturity frameworks, and platform comparisons to guide enterprise Fabric adoption decisions.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 <div class="grid cards" markdown>
 
 -   :material-scale-balance:{ .lg .middle } __Enterprise Data Platform Comparison__
 
     ---
 
-    Fabric vs Databricks vs Snowflake vs Synapse — feature matrix, TCO analysis, and migration guidance for 2026.
+    Microsoft Fabric compared against leading competitor platforms and Azure Synapse — feature matrix, TCO analysis, and migration guidance for 2026.
 
     [:octicons-arrow-right-24: Read comparison](enterprise-data-platform-comparison.md)
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -8,6 +8,9 @@ hero_alt: Step-by-step tutorials — 55 hands-on guides from bronze ingestion to
 
 Hands-on, step-by-step guides covering every aspect of the Microsoft Fabric POC — from environment setup through advanced analytics and federal agency integrations.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Getting Started
 
 <div class="grid cards" markdown>

--- a/docs/use-cases/commercial-healthcare-operations.md
+++ b/docs/use-cases/commercial-healthcare-operations.md
@@ -10,6 +10,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Executive Summary
 
 Commercial healthcare delivery in the United States operates at the intersection of clinical care, regulatory compliance, financial pressure, and operational complexity. A 350-bed regional health system processes more than 30,000 inpatient admissions annually, generates 1.2 million ambulatory encounters, files 2.4 million claims, and manages a 1,400-clinician workforce — while operating on margins frequently below 3%. Hospital systems that fail to optimize operations face catastrophic financial consequences: readmissions alone generate over $2 billion annually in CMS penalties, and operational inefficiencies in supply chain, staffing, and length-of-stay routinely exceed 8% of total expense.
@@ -42,7 +45,7 @@ A modern community-based health system runs the most complex enterprise IT envir
 - Real-time monitoring streams from medical devices (telemetry, vital signs, ventilators, infusion pumps)
 - External feeds (state HIE, payer eligibility, e-prescribing networks, public health reporting)
 
-These systems were never designed to be analyzed together. Reporting is fragmented across 4-12 BI tools (Tableau, Crystal Reports, Power BI, native EHR dashboards, vendor-supplied analytics). Critical decisions — a CFO trying to understand denial trends, a CMO investigating a quality outlier, a CNO planning unit staffing — require pulling data from 4-7 sources, manually reconciling differences, and building one-off Excel models that age out within hours.
+These systems were never designed to be analyzed together. Reporting is fragmented across 4-12 BI tools (a mix of third-party BI and reporting platforms, Power BI, native EHR dashboards, and vendor-supplied analytics). Critical decisions — a CFO trying to understand denial trends, a CMO investigating a quality outlier, a CNO planning unit staffing — require pulling data from 4-7 sources, manually reconciling differences, and building one-off Excel models that age out within hours.
 
 ### The Five Operational Domains This Use Case Addresses
 
@@ -59,7 +62,7 @@ These systems were never designed to be analyzed together. Reporting is fragment
 The status quo in commercial healthcare analytics is some combination of:
 
 1. **EHR-vendor analytics packages** — strong on clinical data the EHR owns, but weak on cross-vendor data, slow to evolve, and frequently behind on modern formats (still bulk-exporting CSVs in 2026)
-2. **Enterprise data warehouse (EDW)** — typically a 15-year-old SQL Server or Teradata platform with stale ETL pipelines and a backlog of 200+ unfulfilled report requests
+2. **Enterprise data warehouse (EDW)** — typically a long-established SQL Server or third-party data-warehouse platform that, while proven for its original batch workloads, often carries stale ETL pipelines and a backlog of 200+ unfulfilled report requests
 3. **Department-level BI** — point solutions that solved one problem (e.g., OR utilization) but never integrate with the rest of the organization
 4. **Manual reconciliation** — Excel macros, Access databases, and tribal knowledge held by a small number of analytics power users
 

--- a/docs/use-cases/financial-fraud-detection.md
+++ b/docs/use-cases/financial-fraud-detection.md
@@ -5,9 +5,12 @@ type: feature
 ---
 # Financial Services: Real-Time Fraud Detection & Regulatory Compliance
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Executive Summary
 
-This use case demonstrates how a mid-tier commercial bank with **$45 billion in assets under management (AUM)** and **2 million retail accounts** leverages Microsoft Fabric to unify real-time fraud detection, anti-money laundering (AML) monitoring, credit risk scoring, and regulatory reporting into a single analytics platform. The architecture replaces a fragmented legacy stack of batch-oriented SAS models, siloed data warehouses, and manual reconciliation processes with a modern lakehouse that delivers sub-second fraud decisioning and continuous compliance.
+This use case demonstrates how a mid-tier commercial bank with **$45 billion in assets under management (AUM)** and **2 million retail accounts** leverages Microsoft Fabric to unify real-time fraud detection, anti-money laundering (AML) monitoring, credit risk scoring, and regulatory reporting into a single analytics platform. The architecture replaces a fragmented legacy stack of batch-oriented statistical-modeling tools, siloed data warehouses, and manual reconciliation processes with a modern lakehouse that delivers sub-second fraud decisioning and continuous compliance.
 
 ### Key Outcomes
 
@@ -31,7 +34,7 @@ Financial institutions face a converging set of pressures:
 1. **Fraud escalation** - Card-not-present (CNP) fraud grew 30% YoY to $9.49B in US losses (Nilson Report 2025). Real-time authorization decisioning is table stakes.
 2. **Regulatory burden** - Banks must comply with BSA/AML (31 CFR 1020), SOX Section 404, PCI DSS v4.0, Basel III capital adequacy, and GLBA privacy requirements simultaneously.
 3. **Stress testing mandates** - CCAR and DFAST require banks with >$10B assets to run quarterly macro-economic scenario analyses across the full loan portfolio.
-4. **Legacy modernization** - Most mid-tier banks run 15-20 year old SAS/Teradata stacks that cannot support real-time ML scoring or streaming ingestion.
+4. **Legacy modernization** - Many mid-tier banks still run 15-20 year old statistical-modeling and data-warehouse stacks built before real-time ML scoring or streaming ingestion were common; those platforms remain capable for their original batch workloads but were not designed for sub-second decisioning.
 
 ### Regulatory Framework
 

--- a/docs/use-cases/insurance-claims-analytics.md
+++ b/docs/use-cases/insurance-claims-analytics.md
@@ -5,6 +5,9 @@ type: feature
 ---
 # Insurance Claims Analytics - P&C Carrier Use Case
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Executive Summary
 
 A mid-market Property & Casualty (P&C) insurance carrier with **$3 billion in gross written premium (GWP)**, approximately **500,000 active policies** across four lines of business, and **120,000 claims per year** deploys Microsoft Fabric to unify claims intake, fraud detection, loss reserving, and statutory reporting into a single lakehouse platform. The solution replaces fragmented legacy systems (AS/400 policy admin, Guidewire ClaimCenter, standalone fraud vendor, Excel-based reserving) with an end-to-end analytics architecture that delivers **ML-driven severity triage at FNOL**, **graph-based fraud ring detection**, **automated loss triangle development**, and **NAIC-compliant statutory data feeds** -- all on a single Fabric F64 capacity.

--- a/docs/use-cases/pharma-clinical-trials.md
+++ b/docs/use-cases/pharma-clinical-trials.md
@@ -15,6 +15,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Executive Summary
 
 A top-20 global pharmaceutical company managing **45 active clinical trials** across

--- a/docs/use-cases/references/README.md
+++ b/docs/use-cases/references/README.md
@@ -4,6 +4,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services (including third-party data file formats such as SAS and SPSS). That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Federal Open Data Portals
 
 | Source | URL | Description | Formats |

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -8,6 +8,11 @@ Complete cross-reference mapping every notebook to its corresponding tutorial, f
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This index references non-Microsoft products and services (for example, IBM DB2 and Oracle as CDC source systems). That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## Table of Contents
 
 - [Casino/Gaming Domain](#casinogaming-domain)

--- a/poc-agenda/DEMO_RUNBOOK.md
+++ b/poc-agenda/DEMO_RUNBOOK.md
@@ -19,6 +19,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📋 Table of Contents
 
 - [1. Pre-Demo Checklist](#1-pre-demo-checklist)
@@ -1106,7 +1111,7 @@ SlotEvents
 | "How long to deploy?" | "Infrastructure deploys in ~1 hour. Full data pipeline with your data: 2-3 weeks typical." |
 | "Can this handle our scale?" | "Fabric scales to petabytes. We'd need to size capacity based on your specific requirements." |
 | "What about compliance?" | "We've built in patterns for NIGC MICS, FinCEN CTR/SAR, W-2G. Customizable for your jurisdiction." |
-| "Differences from Databricks/Snowflake?" | "Fabric is fully integrated - compute, storage, BI, governance in one platform. No data movement." |
+| "How does this compare to other data platforms?" | "Fabric's emphasis is tight integration of compute, storage, BI, and governance in one SaaS platform, which can reduce data movement. Competing platforms have their own strengths — recommend evaluating against your specific requirements and each vendor's current documentation." |
 
 ---
 

--- a/poc-agenda/README.md
+++ b/poc-agenda/README.md
@@ -15,6 +15,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🎲 Casino/Gaming Microsoft Fabric POC Workshop
 
 ![Microsoft Fabric Overview](https://learn.microsoft.com/en-us/fabric/get-started/media/microsoft-fabric-overview/fabric-architecture.png)

--- a/poc-agenda/day3-bi-governance-mirroring.md
+++ b/poc-agenda/day3-bi-governance-mirroring.md
@@ -26,6 +26,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📊 Day 3 Progress Tracker
 
 ```

--- a/tutorials/08-database-mirroring/README.md
+++ b/tutorials/08-database-mirroring/README.md
@@ -17,6 +17,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🔄 Tutorial 08: Database Mirroring - Real-Time Replication
 
 | | |
@@ -292,7 +295,7 @@ Choose tables to mirror from your Snowflake data warehouse:
 2. Click **Start mirroring**
 3. Monitor initial sync progress
 
-> 💡 **Tip:** Snowflake mirroring uses Snowflake Streams under the hood. Ensure your Snowflake account has sufficient storage for stream metadata.
+> 💡 **Tip:** Based on Snowflake's publicly available documentation, Snowflake mirroring uses Snowflake Streams under the hood. Ensure your Snowflake account has sufficient storage for stream metadata, and verify current behavior against Snowflake's official docs.
 
 ---
 

--- a/tutorials/09-advanced-ai-ml/README.md
+++ b/tutorials/09-advanced-ai-ml/README.md
@@ -17,6 +17,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🤖 Tutorial 09: Advanced AI/ML - Predictive Analytics
 
 | | |

--- a/tutorials/10-teradata-migration/README.md
+++ b/tutorials/10-teradata-migration/README.md
@@ -13,6 +13,9 @@
 
 > 🏠 **[Home](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/README.md)** > 📖 **[Tutorials](../index.md)** > 🔄 **Teradata Migration**
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 🔄 Tutorial 10: Teradata to Microsoft Fabric Migration
@@ -47,13 +50,15 @@
 
 ## 📖 Overview
 
-This tutorial provides a comprehensive guide for migrating from **Teradata** data warehouse to **Microsoft Fabric**. You will learn migration strategies, SQL translation patterns, ETL conversion techniques, and best practices for a successful data warehouse modernization.
+This tutorial provides a guide for migrating from a **Teradata** data warehouse to **Microsoft Fabric**. You will learn migration strategies, SQL translation patterns, ETL conversion techniques, and practical steps for a data warehouse modernization. Teradata-side behavior described here is based on Teradata's publicly available documentation (as of this doc's date); always verify against Teradata's current official documentation.
 
-Teradata has been a leading enterprise data warehouse platform for decades. Microsoft Fabric provides a unified analytics platform that can serve as a modern replacement, offering:
+Teradata is a mature, capable enterprise data warehouse platform that has served large analytics workloads for decades and remains a strong choice for many organizations. Microsoft Fabric is a unified analytics platform that some teams choose as a target when consolidating onto the Microsoft stack, offering:
 - **Unified Data Lake** with OneLake and Delta Lake format
-- **Lakehouse architecture** combining the best of data lakes and warehouses
+- **Lakehouse architecture** combining data lake and warehouse patterns
 - **Integrated analytics** from ingestion to Power BI reporting
 - **Pay-per-use pricing** with capacity-based or consumption models
+
+The right platform depends on your requirements; this playbook focuses on the mechanics of moving a workload to Fabric when that is the chosen direction.
 
 ---
 
@@ -855,22 +860,24 @@ flowchart LR
 
 ### 6.3 Third-Party Migration Tools for Teradata
 
+> The following third-party tools are summarized from each vendor's publicly available documentation. Capabilities change often — verify current behavior, support, and pricing with each vendor directly. Listing here is not an endorsement.
+
 #### Datometry (Network-Level Translation)
 
-Datometry provides real-time SQL translation at the network layer, allowing Teradata applications to run on Fabric without code changes.
+Per Datometry's public documentation, Datometry provides SQL translation at the network layer, with the goal of allowing Teradata applications to run against a new target with reduced code changes.
 
-| Feature | Capability |
+| Feature | Capability (per vendor docs) |
 |---------|------------|
-| **SQL Translation** | Automatic Teradata-to-T-SQL conversion |
-| **Application Compatibility** | Existing apps work without modification |
-| **Performance** | Query optimization for Fabric |
-| **Migration Speed** | Up to 90% faster migrations |
+| **SQL Translation** | Teradata-to-T-SQL conversion |
+| **Application Compatibility** | Aims to run existing apps with minimal modification |
+| **Performance** | Query optimization for the target platform |
+| **Migration Speed** | Vendor reports reduced migration effort; validate for your workload |
 
 #### Raven (Datametica/Onix)
 
-Raven automates code conversion for SQL, ETL, and stored procedures.
+Per the vendor's public documentation, Raven automates code conversion for SQL, ETL, and stored procedures.
 
-| Feature | Capability |
+| Feature | Capability (per vendor docs) |
 |---------|------------|
 | **SQL Conversion** | Teradata to Spark SQL / T-SQL |
 | **ETL Migration** | Informatica/Ab Initio to Data Factory |
@@ -1044,7 +1051,7 @@ flowchart LR
 4. Enable CDC capture on Teradata tables
 5. Start replication task
 
-> 💡 **Tip:** Qlik Replicate supports 40+ heterogeneous sources including Teradata, providing a unified CDC solution for complex environments.
+> 💡 **Tip:** Per Qlik's public documentation, Qlik Replicate supports many heterogeneous sources including Teradata, and can serve as a CDC option for complex environments. Verify current source support and licensing with Qlik.
 
 ---
 
@@ -1384,12 +1391,12 @@ After migrating from Teradata to Microsoft Fabric, validating query performance 
 
 ### 10.1 Query Performance Comparison
 
-The following table shows representative benchmarks for a 500 million-row `slot_transactions` fact table. Teradata numbers assume a 10-node system; Fabric numbers use an F64 capacity with V-ORDER enabled.
+The following table shows illustrative, non-authoritative benchmark figures for a 500 million-row `slot_transactions` fact table. These are hypothetical reference points for planning, not measured results, and Teradata is a high-performance platform whose tuned numbers will often differ from those shown. Teradata numbers assume a 10-node system; Fabric numbers use an F64 capacity with V-ORDER enabled. Always benchmark both platforms with your own data and configuration.
 
 | Query Pattern | Example | Teradata (10-node) | Fabric Lakehouse (F64) | Fabric Warehouse (F64) | Notes |
 |---------------|---------|--------------------:|----------------------:|----------------------:|-------|
 | **Point lookup (indexed)** | Single transaction by ID | 0.3 s | 0.8 s | 0.4 s | Teradata PI advantage; Fabric improves with Z-ORDER |
-| **Full scan + aggregation** | Daily revenue across all machines | 12 s | 9 s | 11 s | Fabric columnar + V-ORDER excels |
+| **Full scan + aggregation** | Daily revenue across all machines | 12 s | 9 s | 11 s | Fabric columnar + V-ORDER performs well on scans |
 | **Complex join + window** | Player lifetime value with ranking | 45 s | 28 s | 35 s | Spark scales well with window functions |
 | **QUALIFY-equivalent** | Latest session per player | 18 s | 14 s | 16 s | CTE approach in Fabric is efficient |
 | **Time-series rollup** | Hourly coin-in aggregation, 90 days | 22 s | 10 s | 15 s | Delta Lake partition pruning is very effective |

--- a/tutorials/10-teradata-migration/diagrams/migration-architecture.md
+++ b/tutorials/10-teradata-migration/diagrams/migration-architecture.md
@@ -1,5 +1,8 @@
 # Teradata to Microsoft Fabric Migration Diagrams
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 1. High-Level Migration Architecture
 
 ```mermaid

--- a/tutorials/10-teradata-migration/templates/migration_assessment.md
+++ b/tutorials/10-teradata-migration/templates/migration_assessment.md
@@ -1,5 +1,8 @@
 # Teradata to Microsoft Fabric Migration Assessment
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Project Information
 
 | Field | Value |

--- a/tutorials/10-teradata-migration/templates/migration_checklist.md
+++ b/tutorials/10-teradata-migration/templates/migration_checklist.md
@@ -2,6 +2,9 @@
 
 Use this checklist to track progress through your migration project.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## Phase 1: Assessment & Planning

--- a/tutorials/11-sas-connectivity/README.md
+++ b/tutorials/11-sas-connectivity/README.md
@@ -15,6 +15,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🔌 Tutorial 11: SAS Connectivity to Microsoft Fabric
 
 | | |
@@ -55,7 +60,7 @@ SAS remains a critical analytics platform in many enterprises, especially in:
 - **Gaming/Casino** - Player analytics and compliance reporting
 - **Insurance** - Claims analysis and fraud detection
 
-Connecting SAS to Fabric enables you to leverage existing SAS analytics while modernizing your data platform.
+Connecting SAS to Fabric enables you to leverage existing SAS analytics while modernizing your data platform. The SAS configuration details in this tutorial (LIBNAME options, SAS/ACCESS behavior, ODBC/OLE DB usage) are based on SAS's **publicly available documentation** (as of this page's date); always verify against SAS's current official docs for your specific SAS version and licensing.
 
 ---
 

--- a/tutorials/11-sas-connectivity/diagrams/connectivity-architecture.md
+++ b/tutorials/11-sas-connectivity/diagrams/connectivity-architecture.md
@@ -1,5 +1,8 @@
 # SAS to Microsoft Fabric Connectivity Diagrams
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 1. High-Level Connectivity Architecture
 
 ```mermaid

--- a/tutorials/11-sas-connectivity/templates/odbc_dsn_templates.md
+++ b/tutorials/11-sas-connectivity/templates/odbc_dsn_templates.md
@@ -4,6 +4,11 @@ This document provides ready-to-use ODBC Data Source Name (DSN) configurations f
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## Prerequisites
 
 1. **ODBC Driver 18+ for SQL Server** installed

--- a/tutorials/12-cicd-devops/README.md
+++ b/tutorials/12-cicd-devops/README.md
@@ -15,6 +15,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🔄 Tutorial 12: CI/CD and DevOps for Microsoft Fabric
 
 | | |

--- a/tutorials/13-migration-planning/README.md
+++ b/tutorials/13-migration-planning/README.md
@@ -15,6 +15,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📋 Tutorial 13: Enterprise Migration Planning & Delivery
 
 | | |
@@ -48,7 +53,7 @@
 
 ## 📖 Overview
 
-This comprehensive guide provides everything needed to plan, execute, and deliver a **full enterprise migration** from legacy data platforms (Teradata, Informatica, Oracle, etc.) to **Microsoft Fabric**. It includes:
+This comprehensive guide provides everything needed to plan, execute, and deliver a **full enterprise migration** from existing data platforms (Teradata, Informatica, Oracle, etc.) to **Microsoft Fabric**. These are mature, capable platforms; references to them here are based on each vendor's **publicly available documentation** and are not an authoritative assessment of those products. A migration is the right call only when Fabric is a better fit for your specific needs — where the incumbent platform remains the stronger choice, staying put is a valid outcome. The guide includes:
 
 - **6-month migration timeline** with 3-week sprint cadence
 - **POC to Production** complete journey
@@ -65,12 +70,14 @@ This guide is designed for Data Platform Architects, Program Managers, and Techn
 
 ### Business Objectives
 
-| Objective | Target | Measurement |
+These are **example program targets to set and then validate empirically for your estate** — not guaranteed outcomes and not a claim about any specific source platform's performance or cost. Actual results depend heavily on your current contracts, workloads, and tuning; set your own baselines.
+
+| Objective | Example target (validate) | Measurement |
 |-----------|--------|-------------|
-| **Cost Reduction** | 40-60% TCO reduction | Annual infrastructure spend |
-| **Time to Insight** | 10x faster analytics | Query response time, report refresh |
-| **Operational Efficiency** | 50% less maintenance | Support tickets, manual interventions |
-| **Data Democratization** | 3x more users | Active analytics users |
+| **Cost Reduction** | Set a TCO-reduction goal from your own baseline | Annual infrastructure spend |
+| **Time to Insight** | Faster analytics vs. your measured baseline | Query response time, report refresh |
+| **Operational Efficiency** | Less maintenance vs. your baseline | Support tickets, manual interventions |
+| **Data Democratization** | More active users vs. your baseline | Active analytics users |
 | **Innovation Enablement** | New AI/ML capabilities | Use cases enabled |
 
 ### Technical Objectives
@@ -93,11 +100,11 @@ This guide is designed for Data Platform Architects, Program Managers, and Techn
 
 ```mermaid
 flowchart TB
-    subgraph Source["🏢 Legacy Environment"]
+    subgraph Source["🏢 Source Environment"]
         TD[(Teradata<br/>Data Warehouse)]
         INFA[Informatica<br/>ETL Platform]
         ORACLE[(Oracle<br/>Database)]
-        LEGACY_BI[Legacy<br/>BI Tools]
+        LEGACY_BI[Existing<br/>BI Tools]
     end
 
     subgraph Network["🔒 Secure Connectivity"]

--- a/tutorials/14-security-networking/README.md
+++ b/tutorials/14-security-networking/README.md
@@ -15,6 +15,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🔐 Tutorial 14: Security & Network Configuration
 
 ![Microsoft Fabric Security Layers](https://learn.microsoft.com/en-us/fabric/security/media/security-overview/fabric-security-layers.svg)

--- a/tutorials/15-cost-optimization/README.md
+++ b/tutorials/15-cost-optimization/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📑 Table of Contents
 
 - [📋 Overview](#-overview)

--- a/tutorials/16-performance-tuning/README.md
+++ b/tutorials/16-performance-tuning/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## ⚡ Tutorial 16: Performance Tuning & Optimization
 
 | | |

--- a/tutorials/17-monitoring-alerting/README.md
+++ b/tutorials/17-monitoring-alerting/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📡 Tutorial 17: Monitoring and Observability
 
 | | |

--- a/tutorials/18-data-sharing/README.md
+++ b/tutorials/18-data-sharing/README.md
@@ -16,6 +16,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🔗 Tutorial 18: Data Sharing & OneLake Shortcuts
 
 | | |

--- a/tutorials/19-copilot-ai/README.md
+++ b/tutorials/19-copilot-ai/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🤖 Tutorial 19: Copilot & AI-Assisted Development
 
 | | |

--- a/tutorials/22-networking-connectivity/README.md
+++ b/tutorials/22-networking-connectivity/README.md
@@ -16,6 +16,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 This hands-on tutorial walks you through implementing enterprise networking for Microsoft Fabric, including Private Endpoints, ExpressRoute, VPN configurations, and multi-cloud connectivity. Essential for organizations with hybrid infrastructure or strict compliance requirements.

--- a/tutorials/23-shir-data-gateways/README.md
+++ b/tutorials/23-shir-data-gateways/README.md
@@ -16,6 +16,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 This tutorial provides comprehensive guidance on implementing Self-Hosted Integration Runtime (SHIR) and On-Premises Data Gateways for Microsoft Fabric. Essential for connecting to on-premises data sources, private networks, and legacy systems.

--- a/tutorials/24-snowflake-to-fabric/README.md
+++ b/tutorials/24-snowflake-to-fabric/README.md
@@ -16,6 +16,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## ❄️ Tutorial 24: Snowflake to Microsoft Fabric Migration
 
 | | |
@@ -57,15 +60,15 @@
 
 This tutorial provides a comprehensive guide for migrating from **Snowflake** to **Microsoft Fabric**. You will learn how to assess your Snowflake environment, translate SQL and objects, move data efficiently, and validate the results -- all using casino/gaming industry examples.
 
-### Why Migrate from Snowflake to Microsoft Fabric?
+### Why Some Teams Move from Snowflake to Microsoft Fabric
 
-Snowflake is a powerful cloud-native data warehouse, but organizations are increasingly consolidating onto Microsoft Fabric for its **unified analytics platform** approach. Key drivers include:
+Snowflake is a mature, capable cloud-native data warehouse with deep strengths in elastic compute, multi-cloud reach, and data sharing — for many teams it remains an excellent fit. Some organizations nonetheless choose to consolidate analytics onto Microsoft Fabric, typically for its **unified analytics platform** approach. Based on Snowflake's publicly available documentation (as of this doc's date) and Microsoft's, common considerations include:
 
-- **Unified Platform** -- Fabric combines data engineering, data warehousing, real-time analytics, data science, and Power BI into a single SaaS experience. Snowflake requires separate tools for BI, orchestration, and ML.
-- **Cost Consolidation** -- Snowflake's credit-based pricing for compute and separate storage billing can lead to unpredictable costs. Fabric's capacity-based model (CU) bundles compute, storage, and all workloads into a single SKU.
-- **OneLake & Open Formats** -- All data in Fabric lives in OneLake using Delta Lake (Parquet). No proprietary formats, no vendor lock-in on storage.
-- **Microsoft 365 Integration** -- Native integration with Teams, SharePoint, Excel, and Power BI means analytics reach every knowledge worker without additional licensing.
-- **Governance** -- Microsoft Purview provides unified governance, lineage, and sensitivity labels across the entire estate.
+- **Unified Platform** -- Fabric combines data engineering, data warehousing, real-time analytics, data science, and Power BI into a single SaaS experience. With Snowflake, BI, orchestration, and ML are typically assembled from additional tools or partner services.
+- **Cost Model** -- Snowflake uses credit-based pricing for compute with separately metered storage; Fabric uses a capacity-based model (CU) that bundles compute, storage, and all workloads into a single SKU. Which is more cost-effective depends heavily on your usage pattern — neither is universally cheaper.
+- **OneLake & Open Formats** -- All data in Fabric lives in OneLake using Delta Lake (Parquet). (Snowflake also supports open formats such as Iceberg per its public docs; evaluate based on your storage and interoperability needs.)
+- **Microsoft 365 Integration** -- Native integration with Teams, SharePoint, Excel, and Power BI can make analytics reach Microsoft 365 users with less additional tooling.
+- **Governance** -- Microsoft Purview provides unified governance, lineage, and sensitivity labels across the estate.
 
 ### Cost Comparison at a Glance
 
@@ -79,7 +82,7 @@ Snowflake is a powerful cloud-native data warehouse, but organizations are incre
 | **Data Science** | Snowpark (credit cost) | Fabric Notebooks included |
 | **Governance** | Snowflake Horizon (Enterprise+) | Microsoft Purview included |
 
-> 💡 **Tip:** For a casino running a 2XL Snowflake warehouse 12 hours/day, annual compute alone costs ~$140K in credits. An F64 Fabric capacity covers equivalent workloads plus BI, real-time, and governance for ~$36K/year.
+> 💡 **Tip:** The table above maps roughly equivalent capabilities per each vendor's public documentation; it is not a like-for-like price quote. Cost outcomes vary widely with concurrency, idle time, data volume, and existing Microsoft licensing. As one illustrative scenario, a casino running a 2XL Snowflake warehouse 12 hours/day might incur on the order of ~$140K/year in compute credits, while an F64 Fabric capacity (which also covers BI, real-time, and governance) lists around ~$36K/year — but always model your own workload before drawing conclusions.
 
 ---
 
@@ -1426,16 +1429,18 @@ pie title Annual Cost Comparison - Casino Analytics Platform
 
 > ⚠️ **Important:** This is a simplified comparison for a specific workload profile. Actual savings depend on usage patterns, concurrency, data volumes, and existing Microsoft licensing. Always perform a detailed TCO analysis for your specific environment.
 
-### 8.4 Hidden Cost Advantages of Fabric
+### 8.4 What Fabric Bundles vs. Separately Priced Components
 
-| Fabric Included Feature | Snowflake Separate Cost |
+The following components are included in Fabric capacity, whereas in a Snowflake-centered stack they are commonly licensed or metered separately (per public pricing as of this doc's date). Whether bundling is an advantage depends on whether you would otherwise buy those components — many Snowflake shops already standardize on some of these tools.
+
+| Fabric Included Feature | Commonly Separate in a Snowflake Stack |
 |-------------------------|------------------------|
-| Power BI (Direct Lake) | Tableau/Looker licensing |
-| Data Factory pipelines | Airflow/dbt Cloud |
+| Power BI (Direct Lake) | A separately licensed BI tool |
+| Data Factory pipelines | A separate orchestration tool (e.g., Airflow, dbt Cloud) |
 | Eventstreams (real-time) | Snowpipe credits + streaming costs |
 | Fabric Notebooks (Spark) | Snowpark credits |
 | Microsoft Purview (governance) | Snowflake Horizon (Enterprise+) |
-| OneLake (unified storage) | S3/ADLS + Snowflake storage |
+| OneLake (unified storage) | Object storage + Snowflake storage |
 | Copilot AI assistance | Third-party AI tools |
 
 ---

--- a/tutorials/25-ibm-db2-source/README.md
+++ b/tutorials/25-ibm-db2-source/README.md
@@ -51,11 +51,14 @@
 | :arrow_left: **Previous** | [24-Snowflake to Fabric](../24-snowflake-to-fabric/README.md) |
 | ➡️ **Next** | [26-Multi-Source Streaming](../26-multi-source-streaming/README.md) |
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## 📖 Overview
 
-This tutorial provides a comprehensive guide for connecting **IBM DB2** as a data source for **Microsoft Fabric**. Many casino and gaming organizations run core systems --- cage transaction processing, player tracking, regulatory reporting --- on DB2 mainframes that have been in production for decades.
+This tutorial provides a guide for connecting **IBM DB2** as a data source for **Microsoft Fabric**. Many casino and gaming organizations run core systems --- cage transaction processing, player tracking, regulatory reporting --- on IBM DB2 mainframes, a robust and long-proven platform that has been in production for decades. DB2 behavior, catalog structures, and connectivity details described here are based on IBM's publicly available documentation (as of this doc's date); always verify against IBM's current official documentation.
 
 IBM DB2 comes in three primary variants, each with distinct connectivity considerations:
 

--- a/tutorials/26-multi-source-streaming/README.md
+++ b/tutorials/26-multi-source-streaming/README.md
@@ -16,6 +16,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 📡 Tutorial 26: Multi-Source Real-Time Intelligence
 
 | | |

--- a/tutorials/27-video-security-analytics/README.md
+++ b/tutorials/27-video-security-analytics/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📹 Tutorial 27: Video Security Analytics Pipeline
 
 | | |

--- a/tutorials/28-people-movement-analytics/README.md
+++ b/tutorials/28-people-movement-analytics/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🚶 Tutorial 28: People Movement Analytics
 
 | | |

--- a/tutorials/29-geolocation-analytics/README.md
+++ b/tutorials/29-geolocation-analytics/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📍 Tutorial 29: Geolocation Analytics
 
 | | |

--- a/tutorials/30-tribal-healthcare/README.md
+++ b/tutorials/30-tribal-healthcare/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🏥 Tutorial 30: Tribal Healthcare Analytics
 
 | | |

--- a/tutorials/31-federal-dot-faa/README.md
+++ b/tutorials/31-federal-dot-faa/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## ✈️ Tutorial 31: Federal DOT/FAA Aviation Analytics
 
 | | |

--- a/tutorials/32-usda-agriculture/README.md
+++ b/tutorials/32-usda-agriculture/README.md
@@ -12,6 +12,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🌾 Tutorial 32: USDA Agriculture Analytics
 
 | | |

--- a/tutorials/33-sba-small-business/README.md
+++ b/tutorials/33-sba-small-business/README.md
@@ -12,6 +12,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🏦 Tutorial 33: SBA Small Business Analytics
 
 | | |

--- a/tutorials/34-noaa-weather-climate/README.md
+++ b/tutorials/34-noaa-weather-climate/README.md
@@ -12,6 +12,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🌦️ Tutorial 34: NOAA Weather & Climate Analytics
 
 | | |

--- a/tutorials/35-epa-environment/README.md
+++ b/tutorials/35-epa-environment/README.md
@@ -12,6 +12,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🌿 Tutorial 35: EPA Environmental Analytics
 
 | | |

--- a/tutorials/36-doi-interior/README.md
+++ b/tutorials/36-doi-interior/README.md
@@ -12,6 +12,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🏔️ Tutorial 36: DOI Natural Resources Analytics
 
 | | |

--- a/tutorials/38-doj-justice/README.md
+++ b/tutorials/38-doj-justice/README.md
@@ -12,6 +12,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## ⚖️ Tutorial 38: DOJ Justice Analytics
 
 | | |

--- a/tutorials/40-rag-production/README.md
+++ b/tutorials/40-rag-production/README.md
@@ -17,6 +17,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🔎 Tutorial 40: Production RAG on Microsoft Fabric
 
 | | |

--- a/tutorials/41-synapse-to-fabric/README.md
+++ b/tutorials/41-synapse-to-fabric/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 🔷 Tutorial 41: Azure Synapse Analytics → Microsoft Fabric Migration
 
 | | |

--- a/tutorials/42-databricks-to-fabric/02_workflow_migration.md
+++ b/tutorials/42-databricks-to-fabric/02_workflow_migration.md
@@ -15,6 +15,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 📖 Overview
 
 This is the deep-dive reference for **Step 5** of [Tutorial 42](./README.md): converting **Databricks Workflows / Jobs** to **Fabric Data Pipelines** and **Spark Job Definitions**. The parent tutorial gives you the high-level activity-mapping table; this doc gives you the canonical translation matrix, cluster/trigger/parameter handling, three worked examples (simple notebook, multi-task DAG, and DLT → Materialized Lake View), DLT-specific guidance, bulk-export tooling, and migration anti-patterns.

--- a/tutorials/42-databricks-to-fabric/README.md
+++ b/tutorials/42-databricks-to-fabric/README.md
@@ -16,6 +16,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🧱 Tutorial 42: Databricks → Microsoft Fabric Migration
 
 | | |
@@ -46,23 +49,25 @@
 
 ## 📖 Overview
 
-Databricks → Fabric is the **smoothest cloud-to-cloud migration** because both platforms speak Delta Lake natively. The technical lift is small; the strategic question is bigger — moving onto a Microsoft platform that bundles BI, real-time, governance, and ML alongside Spark, with a single capacity-based commercial model and tighter Microsoft 365 integration.
+Databricks → Fabric tends to be a relatively **smooth cloud-to-cloud migration** because both platforms speak Delta Lake natively. Databricks is a mature, best-in-class lakehouse and Spark platform with deep ML/AI tooling, and for many teams it is the right long-term home. This tutorial is for teams that have decided to consolidate onto a Microsoft platform that bundles BI, real-time, governance, and ML alongside Spark, with a single capacity-based commercial model and tighter Microsoft 365 integration — not an argument that one platform is better than the other.
 
-### Why Migrate from Databricks to Fabric?
+### Comparing Databricks and Fabric
+
+The table below summarizes differences based on each vendor's publicly available documentation (as of this doc's date). It is descriptive, not a ranking — Databricks' Photon engine, DLT, and Unity Catalog are genuine strengths, and the most cost-effective choice depends entirely on your workload mix.
 
 | Concern | Databricks Behavior | Fabric Behavior |
 |---------|---------------------|-----------------|
-| **Compute model** | DBUs per cluster, separate billing per workspace | Capacity Units (CUs) shared across Spark, SQL, Power BI, RTI, ML |
+| **Compute model** | DBUs per cluster, billed per workspace | Capacity Units (CUs) shared across Spark, SQL, Power BI, RTI, ML |
 | **Storage** | Customer-managed ADLS / S3 / GCS | OneLake unified, but ADLS shortcuts work too (no copy) |
 | **BI integration** | Power BI via DBSQL connector or DirectQuery | Direct Lake (no copy, no refresh) on Delta — read-from-OneLake |
 | **Real-time** | Structured Streaming + DLT (Delta Live Tables) | Eventstream + Eventhouse + Materialized Lake Views |
-| **Governance** | Unity Catalog (Databricks-native) | OneLake Catalog + Microsoft Purview (org-wide) |
+| **Governance** | Unity Catalog (Databricks-native, mature) | OneLake Catalog + Microsoft Purview (org-wide) |
 | **MLOps** | MLflow (managed) + Model Serving | Fabric MLflow + AutoML + Real-Time Endpoints |
-| **DBSQL Warehouses** | Photon-accelerated SQL warehouses (separate billing) | Fabric Warehouse + SQL endpoint over Lakehouse |
+| **DBSQL Warehouses** | Photon-accelerated SQL warehouses (separately billed) | Fabric Warehouse + SQL endpoint over Lakehouse |
 | **Notebook UX** | Databricks notebooks | Fabric notebooks (similar; `mssparkutils` API differences) |
 | **Workflows** | Databricks Workflows / Jobs | Fabric Data Pipelines |
 | **DLT (Declarative)** | Delta Live Tables | Materialized Lake Views (Wave 9) |
-| **Cost predictability** | Variable (per-DBU + storage + serverless DBSQL surcharge) | Predictable monthly F-SKU |
+| **Cost shape** | Variable (per-DBU + storage + serverless DBSQL surcharge) | Fixed monthly F-SKU — predictability differs by workload pattern |
 | **Microsoft estate fit** | Bring your own M365 / Power BI / Purview | Native, single tenant, single bill |
 
 ### What This Tutorial Covers

--- a/tutorials/43-redshift-to-fabric/README.md
+++ b/tutorials/43-redshift-to-fabric/README.md
@@ -17,6 +17,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🟧 Tutorial 43: Amazon Redshift → Microsoft Fabric Migration
 
 | | |
@@ -47,19 +50,21 @@
 
 ## 📖 Overview
 
-Amazon Redshift → Fabric is a **multi-cloud migration** — and increasingly common as enterprises consolidate analytics estates onto Microsoft Fabric while keeping operational workloads in AWS. This tutorial walks through extracting Redshift workloads via `UNLOAD` to S3, bringing the data into OneLake (via S3 shortcut or copy), converting Redshift PostgreSQL-flavored DDL into Fabric Warehouse T-SQL, and rationalizing distribution/sort keys, RA3 nodes, and WLM rules into the Fabric capacity model.
+Amazon Redshift → Fabric is a **multi-cloud migration** — a path some enterprises take to consolidate analytics estates onto Microsoft Fabric while keeping operational workloads in AWS. Redshift is a strong, widely-deployed cloud data warehouse with deep AWS-ecosystem integration; this playbook is not an argument that one platform is universally better, but a practical guide for teams that have already decided to move. It walks through extracting Redshift workloads via `UNLOAD` to S3, bringing the data into OneLake (via S3 shortcut or copy), converting Redshift PostgreSQL-flavored DDL into Fabric Warehouse T-SQL, and rationalizing distribution/sort keys, RA3 nodes, and WLM rules into the Fabric capacity model.
 
-### Why Migrate from Redshift to Fabric?
+### Comparing Redshift and Fabric
+
+The table below summarizes differences based on each vendor's publicly available documentation (as of this doc's date). It is descriptive, not a scorecard — Redshift's per-table tuning controls, for example, are a strength for teams that want fine-grained physical control, whereas Fabric favors automatic optimization.
 
 | Concern | Redshift Behavior | Fabric Behavior |
 |---------|-------------------|-----------------|
 | **Compute model** | RA3/DC2 nodes, fixed cluster size or Concurrency Scaling | CU pool shared across all workloads (warehouse, Spark, BI, real-time) |
-| **Storage** | Managed storage on RA3 + S3 (Spectrum); separate egress costs | OneLake unified; S3 readable in place via shortcut |
-| **Performance tuning** | DISTKEY / SORTKEY / encoding decisions per table | V-Order automatic; no DISTKEY/SORTKEY to maintain |
-| **BI integration** | QuickSight or third-party (Tableau, Power BI via ODBC) | Power BI Direct Lake (no copy, no refresh) |
-| **Real-time** | Kinesis + Redshift Streaming Ingestion (separate billing) | Eventstream + Eventhouse native |
-| **Multi-cloud reality** | Locks analytics into AWS region/billing | Reads S3 from Azure via shortcut; supports M365 / Power BI integration |
-| **TCO** | Node-hours + S3 + egress + concurrency scaling charges | Single F-SKU bundles compute, storage, BI, governance |
+| **Storage** | Managed storage on RA3 + S3 (Spectrum) | OneLake unified; S3 readable in place via shortcut |
+| **Performance tuning** | DISTKEY / SORTKEY / encoding give explicit per-table control | V-Order applies automatically; no DISTKEY/SORTKEY to maintain |
+| **BI integration** | QuickSight or other BI tools via ODBC/connectors | Power BI Direct Lake (no copy, no refresh) |
+| **Real-time** | Kinesis + Redshift Streaming Ingestion (separately billed) | Eventstream + Eventhouse native |
+| **Multi-cloud reality** | Tightly integrated with AWS region/billing | Reads S3 from Azure via shortcut; supports M365 / Power BI integration |
+| **Cost shape** | Node-hours + S3 + egress + concurrency scaling charges | Single F-SKU bundles compute, storage, BI, governance |
 
 ### What This Tutorial Covers
 

--- a/tutorials/44-bigquery-to-fabric/README.md
+++ b/tutorials/44-bigquery-to-fabric/README.md
@@ -17,6 +17,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🔵 Tutorial 44: Google BigQuery → Microsoft Fabric Migration
 
 | | |
@@ -47,20 +50,22 @@
 
 ## 📖 Overview
 
-Google BigQuery is a high-performance serverless data warehouse, but a growing number of enterprises are consolidating analytics on Microsoft Fabric to reduce multi-cloud sprawl, simplify BI delivery, and unify governance with the rest of their Microsoft estate. This tutorial walks through migrating each BigQuery workload type into its Fabric equivalent — including the dialect translation, partitioning/clustering conversion, and the cross-cloud egress strategy that makes or breaks the project economics.
+Google BigQuery is a high-performance serverless data warehouse with notable strengths — fast ad-hoc scans, separation of storage and compute, and tight integration with the wider Google Cloud ecosystem. Some enterprises nonetheless choose to consolidate analytics on Microsoft Fabric to reduce multi-cloud sprawl, simplify BI delivery, or unify governance with the rest of their Microsoft estate. This tutorial is a practical guide for teams that have decided to make that move — not a claim that either platform is universally superior. It walks through migrating each BigQuery workload type into its Fabric equivalent — including the dialect translation, partitioning/clustering conversion, and the cross-cloud egress strategy that makes or breaks the project economics.
 
-### Why Migrate from BigQuery to Fabric?
+### Comparing BigQuery and Fabric
+
+The table below summarizes differences based on each vendor's publicly available documentation (as of this doc's date). It is descriptive rather than a verdict; BigQuery's serverless, per-query elasticity, for instance, is a genuine strength for spiky ad-hoc workloads.
 
 | Concern | BigQuery Behavior | Fabric Behavior |
 |---------|-------------------|-----------------|
-| **Cloud surface** | GCP-only (project, IAM, VPC-SC, billing) | Azure-native, integrates with M365, Entra, Purview |
-| **Compute model** | Slots (on-demand or reserved), per-query billing | CU pool — predictable, all workloads share |
+| **Cloud surface** | GCP-native (project, IAM, VPC-SC, billing) | Azure-native; integrates with M365, Entra, Purview |
+| **Compute model** | Slots (on-demand or reserved), per-query billing — elastic for spiky workloads | CU pool — predictable fixed capacity, shared across workloads |
 | **Storage** | BigQuery managed storage + GCS | OneLake unified — one copy, shortcut to GCS during transition |
-| **BI integration** | Looker (separate license, separate tool) or external | Power BI Direct Lake — no copy, no refresh, included |
-| **Real-time** | Pub/Sub + Dataflow + BigQuery streaming inserts | Eventstream + Eventhouse native, lower TCO |
+| **BI integration** | Looker (separate license/tool) or other BI tools | Power BI Direct Lake — no copy, no refresh, included |
+| **Real-time** | Pub/Sub + Dataflow + BigQuery streaming inserts | Eventstream + Eventhouse native |
 | **ML lifecycle** | BigQuery ML inline + Vertex AI | Fabric AutoML + notebooks + Azure ML interop |
 | **Governance** | Data Catalog + IAM + DLP (separate services) | Microsoft Purview unified across the estate |
-| **Egress economics** | Reads cross-cloud incur egress fees from GCP | Once data is in OneLake, no further egress |
+| **Egress economics** | Cross-cloud reads incur egress fees from GCP | Once data is in OneLake, no further cross-cloud egress |
 
 ### What This Tutorial Covers
 

--- a/tutorials/45-onprem-ssas-ssis-ssrs/README.md
+++ b/tutorials/45-onprem-ssas-ssis-ssrs/README.md
@@ -16,6 +16,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📊 Tutorial 45: On-Prem SSAS / SSIS / SSRS → Microsoft Fabric Migration
 
 | | |

--- a/tutorials/53-pharma/README.md
+++ b/tutorials/53-pharma/README.md
@@ -12,6 +12,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 💊 Tutorial 53: Pharma Clinical Trial Analytics
 
 | | |

--- a/tutorials/55-palantir-to-fabric/README.md
+++ b/tutorials/55-palantir-to-fabric/README.md
@@ -23,6 +23,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📋 Table of Contents
 
 - [Overview](#-overview)
@@ -41,7 +46,7 @@
 
 ## 📖 Overview
 
-Palantir Foundry is an end-to-end data platform with a strong ontology layer (semantic objects + properties + links), transforms (Python or SQL), datasets (Parquet + Delta in the platform's object store), pipelines, and apps. Migrations from Foundry to Microsoft Fabric typically cluster around four motivations:
+Palantir Foundry is an end-to-end data platform with a strong ontology layer (semantic objects + properties + links), transforms (Python or SQL), datasets (Parquet + Delta in the platform's object store), pipelines, and apps. It is a capable, mature platform, and the ontology and operational-decision tooling it pioneered are genuine strengths. The descriptions of Foundry here are based on Palantir's **publicly available documentation** (as of this page's date); always verify against Palantir's current official docs. Organizations choose to migrate from Foundry to Microsoft Fabric for several reasons — usually some combination of:
 
 1. **License consolidation** — collapsing Foundry, Power BI, and Azure analytics spend into a single Fabric F-SKU.
 2. **Microsoft-native tooling** — preferring Power BI, Purview, Entra ID, and Microsoft Defender over Foundry-native equivalents.
@@ -56,21 +61,23 @@ This tutorial covers the canonical migration path: **export Foundry datasets and
 
 ## 🎯 Why migrate
 
-| Pain point in Foundry | What Fabric offers in its place |
+The table below maps common drivers for choosing Fabric to the Fabric capability that addresses them. It reflects Foundry behavior as described in Palantir's publicly available documentation; where Foundry is the better fit for a given need, stay on Foundry. This is a comparison from a Microsoft Fabric perspective, not an authoritative assessment of Foundry.
+
+| Driver for considering Fabric | What Fabric offers |
 |---|---|
-| Foundry ontology locked into the platform | **Fabric IQ ontology** — open, queryable from notebooks, agents, and Power BI |
-| Per-seat + per-pipeline pricing | F64 capacity covers all workloads under one SKU |
-| Foundry Forge (apps) | Power Apps + Translytical Task Flows + Power BI |
-| Foundry AIP (LLM agents) | Data Agents, Azure OpenAI, and the Fabric MCP server |
-| Foundry's proprietary dataset format | OneLake Delta tables (open Parquet + Delta Lake spec) |
-| Limited Microsoft 365 / Teams / Entra integration | Native — Entra ID, Teams cards, Outlook embedded reports |
-| Egress costs when integrating with non-Foundry sources | OneLake shortcuts (S3, GCS, ADLS, Dataverse) — zero copy |
+| Want the semantic layer to be queryable outside the platform | **Fabric IQ ontology** — queryable from notebooks, agents, and Power BI |
+| Prefer a single-SKU pricing model | F64 capacity covers all workloads under one SKU |
+| Replacing Foundry Forge (apps) | Power Apps + Translytical Task Flows + Power BI |
+| Replacing Foundry AIP (LLM agents) | Data Agents, Azure OpenAI, and the Fabric MCP server |
+| Want data in an open table format | OneLake Delta tables (open Parquet + Delta Lake spec) |
+| Deep Microsoft 365 / Teams / Entra integration is a priority | Native — Entra ID, Teams cards, Outlook embedded reports |
+| Reducing egress when integrating non-Foundry sources | OneLake shortcuts (S3, GCS, ADLS, Dataverse) — zero copy |
 
 ---
 
 ## 🧭 Component mapping
 
-The canonical Foundry → Fabric translation:
+The Foundry → Fabric translation below is based on Palantir's publicly documented component model (as of this page's date). Verify specifics against Palantir's current official documentation:
 
 | Palantir Foundry component | Microsoft Fabric equivalent | Notes |
 |---|---|---|

--- a/tutorials/56-informatica-to-fabric/README.md
+++ b/tutorials/56-informatica-to-fabric/README.md
@@ -23,6 +23,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📋 Table of Contents
 
 - [Overview](#-overview)
@@ -42,7 +47,7 @@
 
 ## 📖 Overview
 
-Informatica is the long-standing ETL/data-integration incumbent for many enterprises. The two main product lines for migration source are:
+Informatica is a long-established, widely deployed ETL/data-integration platform with deep connectivity, mature data-quality and MDM capabilities, and a large skills base — genuine strengths that any migration should account for. The descriptions of Informatica products here are based on Informatica's **publicly available documentation** (as of this page's date); always verify against Informatica's current official docs. The two main product lines for migration source are:
 
 1. **PowerCenter** — the classic on-prem ETL platform (mappings, workflows, sessions, repositories).
 2. **Intelligent Data Management Cloud (IDMC / formerly IICS)** — the SaaS successor with Data Integration, Data Quality, MDM, B2B Gateway, and more.
@@ -55,22 +60,24 @@ This tutorial covers migrations **from either product** **to Microsoft Fabric**.
 
 ## 🎯 Why migrate
 
-| Pain point in Informatica | What Fabric offers in its place |
+The table below maps common drivers for choosing Fabric to the Fabric capability that addresses them. It reflects Informatica behavior as described in Informatica's publicly available documentation; where Informatica is the better fit for a given need, stay on Informatica. This is a comparison from a Microsoft Fabric perspective, not an authoritative assessment of Informatica.
+
+| Driver for considering Fabric | What Fabric offers |
 |---|---|
-| Per-mapping / per-IPU pricing | Fabric F-SKU covers all workloads under one capacity |
-| Mapping designer thick client (PowerCenter) | Browser-based Dataflows Gen2 and Data Factory |
-| Repository management overhead | Fabric workspaces + Git integration native |
-| Custom transformations in Java/C/Python locked into Informatica | PySpark notebooks — any Python, any package |
-| PowerExchange CDC license cost | Fabric Mirroring (Azure SQL DB, Cosmos DB, Snowflake, Databricks) — free with capacity |
-| Data Quality product separate | Great Expectations / built-in Fabric DQ + Purview classification |
-| MDM as a separate product | Fabric IQ ontology + Data Activator + Translytical task flows |
-| Limited Microsoft 365 / Entra integration | Native Entra ID, sensitivity labels, Defender |
+| Prefer a single-capacity pricing model over per-mapping / per-IPU | Fabric F-SKU covers all workloads under one capacity |
+| Prefer browser-based authoring to the PowerCenter thick client | Browser-based Dataflows Gen2 and Data Factory |
+| Want native Git-based source control for artifacts | Fabric workspaces + Git integration native |
+| Want custom transformations in open Python rather than Informatica-specific code | PySpark notebooks — any Python, any package |
+| Consolidating CDC into the analytics platform | Fabric Mirroring (Azure SQL DB, Cosmos DB, Snowflake, Databricks) — included with capacity |
+| Prefer integrated DQ over a separate product | Great Expectations / built-in Fabric DQ + Purview classification |
+| Prefer integrated master-data patterns over a separate MDM product | Fabric IQ ontology + Data Activator + Translytical task flows |
+| Deep Microsoft 365 / Entra integration is a priority | Native Entra ID, sensitivity labels, Defender |
 
 ---
 
 ## 🧭 Component mapping
 
-The canonical translation matrix:
+The translation matrix below is based on Informatica's publicly documented component model (as of this page's date). Verify specifics against Informatica's current official documentation:
 
 | Informatica component | Microsoft Fabric equivalent | Notes |
 |---|---|---|
@@ -374,16 +381,18 @@ See [Mirroring](../../features/mirroring.md) for the configuration details.
 
 ## 💰 License and cost analysis
 
-A typical PowerCenter → Fabric migration delivers 50-70% cost reduction in steady state, but the migration year often costs more than continuing PowerCenter due to parallel running. Plan for it.
+Cost outcomes vary widely by estate, contract terms, and workload mix, so treat any figures here as illustrative only — build your own model from your actual Informatica contract and a measured Fabric capacity sizing. Some organizations see meaningful steady-state savings; others, depending on their licensing and usage, see less. Note too that the migration year often costs more than simply continuing on Informatica because both platforms run in parallel — plan for it.
 
-| Cost line | PowerCenter steady-state | Fabric steady-state |
+Informatica licensing is negotiated per-customer and is not generally published; the ranges below are rough, illustrative placeholders only and are **not** sourced from Informatica's official pricing. Replace them with your own contracted numbers before making any decision.
+
+| Cost line | Informatica steady-state (illustrative only) | Fabric steady-state |
 |---|---|---|
-| Platform license | $500K-$2M/year | F64 capacity ≈ $100K-$200K/year (covers all workloads) |
-| Per-mapping IPU (IDMC) | Variable, $10-100K/year | Included |
-| PowerExchange CDC license | $50K-$300K/year per source | Free with capacity |
-| Data Quality license | $30K-$150K/year | Free (Great Expectations + Purview) |
-| MDM license | $100K-$500K/year | Free (Fabric IQ + Translytical) |
-| Hardware / hosting | $50K-$200K/year (on-prem PowerCenter) | None (SaaS) |
+| Platform license | Varies by contract | F64 capacity (covers all workloads) — see Azure pricing |
+| Per-mapping IPU (IDMC) | Varies by usage | Included |
+| PowerExchange CDC license | Varies by source count | Included with capacity |
+| Data Quality license | Varies by contract | Included (Great Expectations + Purview) |
+| MDM license | Varies by contract | Included (Fabric IQ + Translytical) |
+| Hardware / hosting | Applies to on-prem PowerCenter | None (SaaS) |
 
 Migration year additional costs:
 

--- a/tutorials/57-databricks-better-together/README.md
+++ b/tutorials/57-databricks-better-together/README.md
@@ -17,6 +17,9 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🤝 Tutorial 57: Databricks Better Together — Mirroring, Security, and the Defense-in-Depth Story
 
 | | |
@@ -206,8 +209,10 @@ Three notebooks, run in order from a Fabric notebook:
 | `notebooks/mirroring/03_query_mirror_from_spark.py` | (no register) | Read the mirror from Spark, T-SQL, sempy. |
 | `notebooks/mirroring/04_compare_mirror_vs_shortcut_vs_iceberg.py` | (reference) | Side-by-side decision matrix. |
 
-> ⚠️ UC row filters / column masks are **not** carried through the mirror —
-> you must re-author security in Fabric. That's exactly what Step 8 does.
+> ⚠️ Per Microsoft's publicly documented mirroring behavior, Unity Catalog row
+> filters / column masks are **not** carried through the mirror — you re-author
+> security in Fabric. That's exactly what Step 8 does. (Verify against the
+> current Databricks and Fabric docs, as both evolve.)
 
 ## 🏗️ Step 6 — Gold star schema
 

--- a/tutorials/57-databricks-better-together/TEST_PLAN.md
+++ b/tutorials/57-databricks-better-together/TEST_PLAN.md
@@ -7,6 +7,9 @@
 Each step has **explicit expected output** so you can stop early if
 something diverges.
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ---
 
 ## Path 1 — Tutorial 57 happy path

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -6,6 +6,11 @@
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services (for example, the Teradata, SAS, Snowflake, and IBM DB2 migration/connectivity tutorials). That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
+---
+
 ## 📑 Table of Contents
 
 - [🎯 Overview](#-overview)
@@ -200,7 +205,7 @@ Complete tutorials in sequence for the best learning experience:
 | | [22 - Networking Connectivity](./22-networking-connectivity/README.md) | Private endpoints, ExpressRoute, VPN, multi-cloud | ~3.5 hours |
 | | [23 - SHIR & Data Gateways](./23-shir-data-gateways/README.md) | Self-hosted runtime, on-premises gateways, hybrid | ~2.5 hours |
 | 🟢 **Migration & Streaming** | | | |
-| | [24 - Snowflake to Fabric](./24-snowflake-to-fabric/README.md) | Snowflake migration, schema mapping, cost comparison | ~3 hours |
+| | [24 - Snowflake to Fabric](./24-snowflake-to-fabric/README.md) | Snowflake migration, schema mapping, cost planning | ~3 hours |
 | | [25 - IBM DB2 Source](./25-ibm-db2-source/README.md) | DB2 connectivity, CDC, EBCDIC handling | ~3 hours |
 | | [26 - Multi-Source Streaming](./26-multi-source-streaming/README.md) | 8 CDC & IoT streaming connectors | ~3 hours |
 | 🔴 **Analytics & Federal Expansions** | | | |


### PR DESCRIPTION
Repo-wide third-party positioning audit so the documentation is **legally defensible**: it must never position the author as an expert in a competitor's product, never read as disparagement, and always frame third-party info as publicly sourced. Audited **every** Markdown file that names a non-Microsoft vendor (163 files scanned; 109 now carry the standard disclaimer).

## Policy applied
- **Standard disclaimer** ("Third-party references — publicly sourced, good-faith comparison") added after the H1 of every doc that names a competitor.
- **White papers / research** → competitor names removed entirely; neutral "Competitor A/B" labels + legend; claims framed as publicly sourced.
- **Decision / comparison / TCO / strategy** → de-named in positioning; superiority softened; competitor strengths acknowledged. (Visible link text softened; **file paths & anchors unchanged**.)
- **Migration / connectivity tutorials** → vendor names **kept** (search relevance) + disclaimer + non-expert, publicly-sourced framing; one-to-one mappings caveated. Replaced an unsourced Informatica license-cost table with a clearly-illustrative model.
- **Feature / best-practice / use-case / industry** → factual connector/source/target names kept (S3, GCS, Snowflake mirroring, Oracle/SAP sources) + disclaimer; only genuine positioning lines de-named.

## Safeguards
- **No file renames, no link/slug/anchor changes.**
- Microsoft/Azure/open-source names kept throughout (Synapse, Power BI, Purview, SSIS/SSAS/SSRS, Spark, Delta, Iceberg, dbt, Airflow, Kafka).
- False positives correctly preserved: "SAS" (Slot Accounting System / Shared Access Signature), "Snowflake schema" (data modeling), "GCP" (Good Clinical Practice), S3 IoT tiers, the `# Databricks notebook source` magic header.

## Note on CI
The `Test Documentation (Playwright)` check tests the **live deployed site** and is already red on `main` for pre-existing broken links unrelated to this PR (newer pages not yet deployed). Not caused by these text-only edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)