### PR TITLE
fix(docs): absolute footer link (fixes broken-link CI) + LLM-provider disclaimers

### DIFF
--- a/docs/best-practices/llm-cost-tracking.md
+++ b/docs/best-practices/llm-cost-tracking.md
@@ -22,6 +22,9 @@ type: deep-dive
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Why LLM Cost Tracking
 
 Fabric's AI surface area exploded in 2025-2026: Copilot in every workload, Data Agents on every domain, AI Functions on every Spark cluster, Eventhouse vector search, and an open door to Azure OpenAI / Anthropic / OpenAI from any notebook. Each of these consumes tokens. Tokens cost real money — and unlike CU consumption, they don't show up cleanly on a single Fabric capacity meter.

--- a/docs/features/fabric-mcp.md
+++ b/docs/features/fabric-mcp.md
@@ -21,6 +21,9 @@ type: feature
 
 ---
 
+!!! note "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 The Fabric MCP Server is Microsoft Fabric's platform-level implementation of the **Model Context Protocol (MCP)** -- an open standard that lets AI agents discover, query, and govern Fabric items through a structured tool interface. Instead of requiring agents to call REST APIs directly or generate ad-hoc queries, the MCP Server exposes a curated set of tools that encapsulate Fabric operations with built-in authentication, authorization, and governance controls.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,7 @@ copyright: >-
   Copyright &copy; 2026 Supercharge Microsoft Fabric &middot;
   <a href="https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric">GitHub</a> &middot;
   <a href="https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/issues">Issues</a> &middot;
-  <a href="FIELD_QUESTIONS/">Field Questions</a>
+  <a href="https://fgarofalo56.github.io/Suppercharge_Microsoft_Fabric/FIELD_QUESTIONS/">Field Questions</a>
 
 # Documentation directory (default: docs/)
 docs_dir: docs


### PR DESCRIPTION
Final cleanup after the branding + positioning audit.

- **Footer link fix:** the copyright "Field Questions" link was relative (`FIELD_QUESTIONS/`), so it resolved to `/<subpath>/FIELD_QUESTIONS/` and 404'd on every non-root page — the persistent failure in the `Test Documentation (Playwright)` internal-link check. Now an absolute Pages URL, matching the GitHub/Issues footer links. (The other links that test reported were stale-deploy artifacts already absent from current source; they clear on the next publish.)
- **LLM-provider disclaimers:** added the standard "publicly sourced, good-faith comparison" disclaimer to `fabric-mcp.md` and `llm-cost-tracking.md`, which name AI providers (Anthropic, OpenAI, Mistral, Cohere, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)