### PR TITLE
fix(ci): auto-publish docs when hooks/ or overrides/ change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,11 @@ on:
       - 'notebooks/**/README.md'
       - 'infra/README.md'
       - 'mkdocs.yml'
+      # Build-time hooks and theme overrides change the rendered HTML, so a
+      # change to either must rebuild the docs (previously omitted — so a
+      # hooks/ or overrides/ fix never published without a manual dispatch).
+      - 'hooks/**'
+      - 'overrides/**'
       - 'README.md'
       - 'CHANGELOG.md'
       - 'CONTRIBUTING.md'


### PR DESCRIPTION
The Deploy Documentation workflow watched `docs/`, `mkdocs.yml`, etc. but **not** `hooks/**` (build hooks like `page_polish.py`) or `overrides/**` (theme templates). Both change the rendered HTML, so fixes there never auto-published — the next-step relative-link fix (#101) had to be published via a manual `workflow_dispatch`. Adds both globs to the path filter so future hook/template changes deploy automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)