### PR TITLE
docs: deepen vendor audit + restyle disclaimer as a prominent box

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,7 +980,8 @@ flowchart LR
     T26 --> T27 --> T28 --> T29 --> T30 --> T31
 ```
 
-> **Note on third-party references:** The migration tutorials (Teradata, Snowflake, IBM DB2) and any platform comparisons reference non-Microsoft products. That information is publicly sourced from each vendor's official documentation and offered for good-faith comparison only; this personal project does not claim authority over those products. Always verify against the vendor's current docs.
+> [!NOTE]
+> **Third-party references are publicly sourced.** The migration tutorials (Teradata, Snowflake, IBM DB2) and any platform comparisons reference non-Microsoft products. That information is publicly sourced from each vendor's official documentation and offered for good-faith comparison only; this personal project does not claim authority over those products. Always verify against the vendor's current docs.
 
 <table>
 <tr>

--- a/data_generation/README.md
+++ b/data_generation/README.md
@@ -6,7 +6,7 @@ Synthetic data generators for casino/gaming, federal agencies, streaming CDC, an
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services (for example, IBM DB2 and Oracle as simulated CDC source systems). That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/DECISION_TREES.md
+++ b/docs/DECISION_TREES.md
@@ -10,7 +10,7 @@ type: decision
 
 This document provides structured decision flowcharts for the most common "which Fabric component should I use?" questions. Each section contains a Mermaid flowchart, a comparison table, a "Choose X when..." summary, and a real-world example drawn from the POC.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -16,7 +16,7 @@ type: reference
 
 </div>
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---
@@ -1560,11 +1560,8 @@ See: [Data Agents](features/data-agents.md) | [Fabric IQ](features/fabric-iq.md)
 
 ## 🔄 Migrations
 
-> **Note on third-party platforms.** The migration notes below describe how to move
-> *into* Microsoft Fabric. Details about each source platform are summarized from
-> that vendor's publicly available documentation and may change; always confirm
-> against the vendor's current official docs. Nothing here claims expertise in, or
-> authority over, those third-party products.
+!!! info "Migrating into Fabric — third-party details are publicly sourced"
+    The migration notes below describe how to move *into* Microsoft Fabric. Details about each source platform are summarized from that vendor's publicly available documentation and may change; always confirm against the vendor's current official docs. Nothing here claims expertise in, or authority over, those third-party products.
 
 ### How do I migrate from Synapse Analytics?
 

--- a/docs/FIELD_QUESTIONS.md
+++ b/docs/FIELD_QUESTIONS.md
@@ -24,7 +24,7 @@ Fabric adoption — scenarios that the standard product docs don't address direc
 but that come up repeatedly in field engagements. Each topic links back to the
 authoritative Microsoft Learn citation.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/GENERATOR_API_REFERENCE.md
+++ b/docs/GENERATOR_API_REFERENCE.md
@@ -18,7 +18,7 @@ type: reference
 
 **TL;DR** -- This document covers all 19 data generators in the `data_generation/generators/` package. Every generator inherits from `BaseGenerator`, which provides reproducible seeding, output serialization (DataFrame, Parquet, JSON), batch iteration, and PII masking helpers. Generators span four domains: Casino/Gaming (6), Federal Agency (7), Analytics (3), and Streaming (3).
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -16,7 +16,7 @@ type: reference
 
 </div>
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/MIGRATION_AND_RTI_RESEARCH.md
+++ b/docs/MIGRATION_AND_RTI_RESEARCH.md
@@ -19,7 +19,7 @@ type: deep-dive
 > Research compiled: 2026-03-11
 > Sources: Microsoft Learn, Brave Web Search, Microsoft Docs MCP
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/MY_RESOURCES.md
+++ b/docs/MY_RESOURCES.md
@@ -7,7 +7,7 @@ type: reference
 
 > Per-deployment reference sheet. Fill in your **own** Azure resource IDs locally so every tutorial pulls from one place instead of hunting through multiple portals.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 !!! warning "Do not commit real values to this file"

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -16,7 +16,7 @@ type: deep-dive
 
 </div>
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ type: deep-dive
 
 **Last Updated:** `2025-01-21` | **Version:** 1.0.0
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/02_DATA_GATEWAY.md
+++ b/docs/best-practices/02_DATA_GATEWAY.md
@@ -19,6 +19,9 @@ type: deep-dive
 </div>
 ---
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 📋 Overview
 
 The on-premises data gateway is critical for connecting Fabric to on-premises data sources like Oracle, SQL Server, and file systems. Proper configuration dramatically impacts data movement performance.

--- a/docs/best-practices/03_PIPELINES_DATA_MOVEMENT.md
+++ b/docs/best-practices/03_PIPELINES_DATA_MOVEMENT.md
@@ -19,6 +19,9 @@ type: deep-dive
 </div>
 ---
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 📋 Overview
 
 This guide covers best practices for data movement in Microsoft Fabric, including ETL vs ELT patterns, copy activity optimization, and different load strategies (full, incremental, CDC).

--- a/docs/best-practices/04_METADATA_DRIVEN_PIPELINES.md
+++ b/docs/best-practices/04_METADATA_DRIVEN_PIPELINES.md
@@ -19,6 +19,9 @@ type: deep-dive
 </div>
 ---
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 📋 Overview
 
 Metadata-driven pipelines enable dynamic, configuration-based data movement without hardcoding source and destination details. This approach significantly reduces maintenance, improves reusability, and accelerates onboarding of new data sources.

--- a/docs/best-practices/06_DATAFLOWS.md
+++ b/docs/best-practices/06_DATAFLOWS.md
@@ -19,7 +19,7 @@ type: deep-dive
 </div>
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/07_LAKEHOUSE_SETUP.md
+++ b/docs/best-practices/07_LAKEHOUSE_SETUP.md
@@ -19,7 +19,7 @@ type: deep-dive
 </div>
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/09_SOURCE_SPECIFIC_PATTERNS.md
+++ b/docs/best-practices/09_SOURCE_SPECIFIC_PATTERNS.md
@@ -19,6 +19,9 @@ type: deep-dive
 </div>
 ---
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 📋 Overview
 
 Migrating data from Oracle and SQL Server to Microsoft Fabric requires specific patterns for optimal performance. This guide covers large table extraction, parallel loading, incremental patterns, and gateway optimization.

--- a/docs/best-practices/10_DECISION_GUIDE.md
+++ b/docs/best-practices/10_DECISION_GUIDE.md
@@ -18,7 +18,7 @@ type: deep-dive
 
 </div>
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/11_ORACLE_GATEWAY_TROUBLESHOOTING.md
+++ b/docs/best-practices/11_ORACLE_GATEWAY_TROUBLESHOOTING.md
@@ -19,6 +19,9 @@ type: deep-dive
 </div>
 ---
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 📋 Overview
 
 This guide addresses common issues when moving data from on-premises Oracle to Microsoft Fabric, including slow gateway performance, ForEach loops not running in parallel, and maximizing concurrent connections.

--- a/docs/best-practices/README.md
+++ b/docs/best-practices/README.md
@@ -11,7 +11,7 @@
 
 </div>
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/data-management/data-product-framework.md
+++ b/docs/best-practices/data-management/data-product-framework.md
@@ -22,7 +22,7 @@ type: deep-dive
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/data-management/late-arriving-data.md
+++ b/docs/best-practices/data-management/late-arriving-data.md
@@ -22,7 +22,7 @@ type: deep-dive
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/data-management/reference-data-versioning.md
+++ b/docs/best-practices/data-management/reference-data-versioning.md
@@ -22,7 +22,7 @@ type: deep-dive
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/data-sharing-federation.md
+++ b/docs/best-practices/data-sharing-federation.md
@@ -21,7 +21,7 @@ type: deep-dive
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/etl-elt-comparison-guide.md
+++ b/docs/best-practices/etl-elt-comparison-guide.md
@@ -15,7 +15,7 @@ type: deep-dive
 
 </div>
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/incremental-refresh-cdc.md
+++ b/docs/best-practices/incremental-refresh-cdc.md
@@ -21,7 +21,7 @@ type: deep-dive
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/index.md
+++ b/docs/best-practices/index.md
@@ -8,6 +8,9 @@ hero_alt: "Best Practices — Architecture, security, performance, and operation
 
 Proven patterns, architectural guidance, and operational best practices for production Microsoft Fabric deployments.
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## Workspace & Infrastructure
 
 <div class="grid cards" markdown>

--- a/docs/best-practices/lakehouse-warehouse-sqldb-decision-guide.md
+++ b/docs/best-practices/lakehouse-warehouse-sqldb-decision-guide.md
@@ -15,7 +15,7 @@ type: deep-dive
 
 </div>
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/llm-cost-tracking.md
+++ b/docs/best-practices/llm-cost-tracking.md
@@ -22,7 +22,7 @@ type: deep-dive
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Why LLM Cost Tracking

--- a/docs/best-practices/migration-patterns.md
+++ b/docs/best-practices/migration-patterns.md
@@ -35,7 +35,7 @@ type: deep-dive
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/network-security.md
+++ b/docs/best-practices/network-security.md
@@ -21,7 +21,7 @@ type: deep-dive
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/operations/observability-stack.md
+++ b/docs/best-practices/operations/observability-stack.md
@@ -22,6 +22,9 @@ type: runbook
 
 ---
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 This document is the **end-to-end observability blueprint** for the Microsoft Fabric platform. It is the integration layer that ties together every signal source, every storage backend, every alert channel, and every visualization tool into a single, coherent stack. Where [Monitoring & Observability](../monitoring-observability.md) introduces the pillars and [Alerting & Data Activator](../alerting-data-activator.md) covers business-event triggers, this guide answers the operational question:

--- a/docs/best-practices/performance-parallelism.md
+++ b/docs/best-practices/performance-parallelism.md
@@ -21,6 +21,9 @@ type: deep-dive
 
 ---
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 📖 Overview
 
 Performance optimization in Microsoft Fabric spans multiple workloads: Copy Activities, Spark notebooks, pipeline orchestration, Direct Lake semantic models, and KQL queries. This guide provides concrete configuration recommendations, benchmark guidelines, and cost-performance trade-off analysis for the casino gaming, federal agency, and healthcare workloads in this project.

--- a/docs/best-practices/security/audit-trail-immutability.md
+++ b/docs/best-practices/security/audit-trail-immutability.md
@@ -22,7 +22,7 @@ type: compliance
 
 > **Disclaimer:** This document provides architectural and technical guidance for audit-trail immutability on Microsoft Fabric. It is **not** legal advice, regulatory interpretation, or a guarantee of compliance with any specific statute (SOX, HIPAA, GDPR, PCI-DSS, 21 CFR Part 11, NIGC MICS, FedRAMP). Audit-evidence requirements vary by jurisdiction, regulator, and contract. Engage qualified legal counsel and your audit firm before relying on these patterns to satisfy any specific obligation.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/security/data-exfiltration-prevention.md
+++ b/docs/best-practices/security/data-exfiltration-prevention.md
@@ -22,7 +22,7 @@ type: compliance
 
 > **Disclaimer:** This document describes architectural and technical controls to reduce the likelihood and impact of data exfiltration. It is not a guarantee. A determined insider with sufficient privilege can defeat any control. Layered defense, behavior monitoring, and process controls are equally important. Engage your security and legal teams before relying on these patterns in regulated environments.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/security/onelake-defense-in-depth.md
+++ b/docs/best-practices/security/onelake-defense-in-depth.md
@@ -12,7 +12,7 @@ type: best-practice
 > Direct Lake fallback gotcha, and the canonical configuration vector for
 > each layer (UI / REST / T-SQL / Bicep).
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/best-practices/security/supply-chain-security.md
+++ b/docs/best-practices/security/supply-chain-security.md
@@ -20,9 +20,10 @@ type: compliance
 
 **Last Updated:** `2026-04-27` | **Version:** 1.0.0 | **Wave 5 Feature:** 5.8 | **Anchor:** [SOC 2 Type II Readiness](soc2-type2-readiness.md)
 
-> **Disclaimer:** This document provides architectural and technical guidance for supply chain security on Microsoft Fabric. It is **not** a substitute for a formal third-party risk management program, secure software development lifecycle (SSDLC) certification, or legal counsel. Coordinate with your organization's CISO, procurement, and legal teams before relying on these patterns in regulated environments.
+!!! warning "Disclaimer"
+    This document provides architectural and technical guidance for supply chain security on Microsoft Fabric. It is **not** a substitute for a formal third-party risk management program, secure software development lifecycle (SSDLC) certification, or legal counsel. Coordinate with your organization's CISO, procurement, and legal teams before relying on these patterns in regulated environments.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/decisions/etl-elt-streaming.md
+++ b/docs/decisions/etl-elt-streaming.md
@@ -15,7 +15,7 @@ type: decision
 
 </div>
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/decisions/fabric-databricks-synapse.md
+++ b/docs/decisions/fabric-databricks-synapse.md
@@ -15,7 +15,7 @@ type: decision
 
 </div>
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -19,7 +19,7 @@ hero_alt: Decisions — Architecture trade-offs and ADRs
 
 **Last Updated:** `2026-05-05` | **Version:** 1.0.0
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/decisions/lakehouse-warehouse-sqldb.md
+++ b/docs/decisions/lakehouse-warehouse-sqldb.md
@@ -19,7 +19,7 @@ type: decision
 
 **Last Updated:** `2026-05-05` | **Version:** 1.0.0
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/features/copy-job-cdc.md
+++ b/docs/features/copy-job-cdc.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Overview

--- a/docs/features/database-hub.md
+++ b/docs/features/database-hub.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/features/dataflow-gen2.md
+++ b/docs/features/dataflow-gen2.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Overview

--- a/docs/features/dbt-fabric-integration.md
+++ b/docs/features/dbt-fabric-integration.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Overview

--- a/docs/features/direct-lake.md
+++ b/docs/features/direct-lake.md
@@ -22,6 +22,9 @@ type: feature
 
 ---
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 Direct Lake is Microsoft Fabric's revolutionary connectivity mode for Power BI that reads Delta and Parquet files directly from OneLake without importing data into the semantic model or issuing live queries through a SQL endpoint. It combines the performance of Import mode (in-memory columnar engine) with the freshness of DirectQuery (always up-to-date data), eliminating the traditional trade-off between speed and currency that has defined Power BI deployments for a decade.

--- a/docs/features/eval-harness-llm.md
+++ b/docs/features/eval-harness-llm.md
@@ -22,7 +22,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/features/eventhouse-vector-database.md
+++ b/docs/features/eventhouse-vector-database.md
@@ -21,6 +21,9 @@ type: feature
 
 ---
 
+!!! info "Third-party references — publicly sourced, good-faith comparison"
+    This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
+
 ## 🎯 Overview
 
 Microsoft Fabric's Eventhouse — the core engine behind Real-Time Intelligence — can function as a **vector database** for AI and machine learning scenarios. By combining KQL's powerful analytical capabilities with vector storage, embedding generation, and similarity search, Eventhouse enables Retrieval-Augmented Generation (RAG), semantic search, and AI-powered analytics directly within the Fabric ecosystem.
@@ -38,7 +41,7 @@ Microsoft Fabric's Eventhouse — the core engine behind Real-Time Intelligence 
 
 ### Why Eventhouse for Vector Search?
 
-Traditional vector databases are standalone systems that require separate infrastructure, ETL pipelines, and operational overhead. Eventhouse eliminates this complexity by embedding vector capabilities directly into the real-time analytics engine you're already using:
+Dedicated vector databases such as Pinecone, Weaviate, and Qdrant are mature, capable systems with rich features — including approximate-nearest-neighbor (ANN) indexes that Eventhouse does not offer (see [Limitations](#-limitations)) — and they remain the stronger choice for very large or ANN-heavy vector workloads. The trade-off is that they are standalone systems requiring separate infrastructure, ETL pipelines, and operational overhead. Eventhouse takes a different approach: it embeds vector capabilities directly into the real-time analytics engine you're already using, which is compelling when your vectors live alongside structured Fabric data:
 
 ```
 Traditional Approach:                    Fabric Eventhouse Approach:

--- a/docs/features/fabric-mcp.md
+++ b/docs/features/fabric-mcp.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Overview

--- a/docs/features/federated-fabric-gcc.md
+++ b/docs/features/federated-fabric-gcc.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Overview

--- a/docs/features/mirroring.md
+++ b/docs/features/mirroring.md
@@ -22,7 +22,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Overview

--- a/docs/features/onelake-catalog.md
+++ b/docs/features/onelake-catalog.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/features/onelake-iceberg-interop.md
+++ b/docs/features/onelake-iceberg-interop.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Overview

--- a/docs/features/onelake-shortcuts-s3-gcs-dataverse.md
+++ b/docs/features/onelake-shortcuts-s3-gcs-dataverse.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Overview

--- a/docs/features/rag-patterns-deep-dive.md
+++ b/docs/features/rag-patterns-deep-dive.md
@@ -22,7 +22,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/features/real-time-hub.md
+++ b/docs/features/real-time-hub.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/features/real-time-intelligence.md
+++ b/docs/features/real-time-intelligence.md
@@ -22,7 +22,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/features/spark-environments-job-definitions.md
+++ b/docs/features/spark-environments-job-definitions.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/features/vnet-data-gateway.md
+++ b/docs/features/vnet-data-gateway.md
@@ -21,7 +21,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Overview

--- a/docs/industries/healthcare.md
+++ b/docs/industries/healthcare.md
@@ -26,7 +26,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Scenario Overview

--- a/docs/industries/manufacturing.md
+++ b/docs/industries/manufacturing.md
@@ -26,7 +26,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Scenario Overview

--- a/docs/microsoft-fabric-features-april-2026.md
+++ b/docs/microsoft-fabric-features-april-2026.md
@@ -17,7 +17,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/docs/research/ai-readiness-assessment.md
+++ b/docs/research/ai-readiness-assessment.md
@@ -7,7 +7,7 @@ type: deep-dive
 
 > A structured framework for evaluating an organization's readiness to adopt Fabric AI capabilities — Copilot, AutoML, Semantic Link, Data Agents, and AI Functions — with a maturity model, assessment questionnaire, and implementation roadmap.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Executive Summary

--- a/docs/research/data-mesh-maturity-model.md
+++ b/docs/research/data-mesh-maturity-model.md
@@ -7,7 +7,7 @@ type: deep-dive
 
 > How to implement Data Mesh principles using Fabric constructs — workspaces as domains, OneLake as federated storage, Purview as the governance plane, and data products delivered via lakehouses and semantic models. Includes maturity levels, assessment criteria, and a migration path from centralized to mesh.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Executive Summary

--- a/docs/research/enterprise-data-platform-comparison.md
+++ b/docs/research/enterprise-data-platform-comparison.md
@@ -7,7 +7,7 @@ type: deep-dive
 
 > Microsoft Fabric compared against leading competitor platforms and Azure Synapse Analytics — a structured comparison to guide platform selection for enterprise analytics, data engineering, and AI workloads.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 !!! abstract "Competitor legend"

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -7,7 +7,7 @@ hero_alt: "White Papers — Research, maturity models, and platform comparisons 
 
 Strategic analysis, maturity frameworks, and platform comparisons to guide enterprise Fabric adoption decisions.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 <div class="grid cards" markdown>

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -8,7 +8,7 @@ hero_alt: Step-by-step tutorials — 55 hands-on guides from bronze ingestion to
 
 Hands-on, step-by-step guides covering every aspect of the Microsoft Fabric POC — from environment setup through advanced analytics and federal agency integrations.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Getting Started

--- a/docs/use-cases/commercial-healthcare-operations.md
+++ b/docs/use-cases/commercial-healthcare-operations.md
@@ -10,7 +10,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Executive Summary

--- a/docs/use-cases/financial-fraud-detection.md
+++ b/docs/use-cases/financial-fraud-detection.md
@@ -5,7 +5,7 @@ type: feature
 ---
 # Financial Services: Real-Time Fraud Detection & Regulatory Compliance
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Executive Summary

--- a/docs/use-cases/insurance-claims-analytics.md
+++ b/docs/use-cases/insurance-claims-analytics.md
@@ -5,7 +5,7 @@ type: feature
 ---
 # Insurance Claims Analytics - P&C Carrier Use Case
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Executive Summary

--- a/docs/use-cases/pharma-clinical-trials.md
+++ b/docs/use-cases/pharma-clinical-trials.md
@@ -15,7 +15,7 @@ type: feature
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Executive Summary

--- a/docs/use-cases/references/README.md
+++ b/docs/use-cases/references/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services (including third-party data file formats such as SAS and SPSS). That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Federal Open Data Portals

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -210,7 +210,7 @@ nav:
       - Cost Breakdown: diagrams/cost-breakdown.md
     - Decision Trees:
       - Overview: decisions/index.md
-      - Fabric vs Databricks vs Synapse: decisions/fabric-databricks-synapse.md
+      - Fabric vs Competitor vs Synapse: decisions/fabric-databricks-synapse.md
       - Lakehouse vs Warehouse vs SQL DB: decisions/lakehouse-warehouse-sqldb.md
       - Direct Lake vs Import vs DirectQuery: decisions/direct-lake-import-directquery.md
       - ETL vs ELT vs Streaming: decisions/etl-elt-streaming.md

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -8,7 +8,7 @@ Complete cross-reference mapping every notebook to its corresponding tutorial, f
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This index references non-Microsoft products and services (for example, IBM DB2 and Oracle as CDC source systems). That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/poc-agenda/DEMO_RUNBOOK.md
+++ b/poc-agenda/DEMO_RUNBOOK.md
@@ -19,7 +19,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/poc-agenda/README.md
+++ b/poc-agenda/README.md
@@ -15,7 +15,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/poc-agenda/day3-bi-governance-mirroring.md
+++ b/poc-agenda/day3-bi-governance-mirroring.md
@@ -26,7 +26,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/08-database-mirroring/README.md
+++ b/tutorials/08-database-mirroring/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🔄 Tutorial 08: Database Mirroring - Real-Time Replication

--- a/tutorials/09-advanced-ai-ml/README.md
+++ b/tutorials/09-advanced-ai-ml/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/10-teradata-migration/README.md
+++ b/tutorials/10-teradata-migration/README.md
@@ -13,7 +13,7 @@
 
 > 🏠 **[Home](https://github.com/fgarofalo56/Suppercharge_Microsoft_Fabric/blob/main/README.md)** > 📖 **[Tutorials](../index.md)** > 🔄 **Teradata Migration**
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---
@@ -860,7 +860,8 @@ flowchart LR
 
 ### 6.3 Third-Party Migration Tools for Teradata
 
-> The following third-party tools are summarized from each vendor's publicly available documentation. Capabilities change often — verify current behavior, support, and pricing with each vendor directly. Listing here is not an endorsement.
+!!! info "Third-party tools — publicly sourced, not an endorsement"
+    The following third-party tools are summarized from each vendor's publicly available documentation. Capabilities change often — verify current behavior, support, and pricing with each vendor directly. Listing here is not an endorsement.
 
 #### Datometry (Network-Level Translation)
 

--- a/tutorials/10-teradata-migration/diagrams/migration-architecture.md
+++ b/tutorials/10-teradata-migration/diagrams/migration-architecture.md
@@ -1,6 +1,6 @@
 # Teradata to Microsoft Fabric Migration Diagrams
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 1. High-Level Migration Architecture

--- a/tutorials/10-teradata-migration/templates/migration_assessment.md
+++ b/tutorials/10-teradata-migration/templates/migration_assessment.md
@@ -1,6 +1,6 @@
 # Teradata to Microsoft Fabric Migration Assessment
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## Project Information

--- a/tutorials/10-teradata-migration/templates/migration_checklist.md
+++ b/tutorials/10-teradata-migration/templates/migration_checklist.md
@@ -2,7 +2,7 @@
 
 Use this checklist to track progress through your migration project.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/11-sas-connectivity/README.md
+++ b/tutorials/11-sas-connectivity/README.md
@@ -15,7 +15,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/11-sas-connectivity/diagrams/connectivity-architecture.md
+++ b/tutorials/11-sas-connectivity/diagrams/connectivity-architecture.md
@@ -1,6 +1,6 @@
 # SAS to Microsoft Fabric Connectivity Diagrams
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 1. High-Level Connectivity Architecture

--- a/tutorials/11-sas-connectivity/templates/odbc_dsn_templates.md
+++ b/tutorials/11-sas-connectivity/templates/odbc_dsn_templates.md
@@ -4,7 +4,7 @@ This document provides ready-to-use ODBC Data Source Name (DSN) configurations f
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/12-cicd-devops/README.md
+++ b/tutorials/12-cicd-devops/README.md
@@ -15,7 +15,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/13-migration-planning/README.md
+++ b/tutorials/13-migration-planning/README.md
@@ -15,7 +15,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/14-security-networking/README.md
+++ b/tutorials/14-security-networking/README.md
@@ -15,7 +15,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/15-cost-optimization/README.md
+++ b/tutorials/15-cost-optimization/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/16-performance-tuning/README.md
+++ b/tutorials/16-performance-tuning/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/17-monitoring-alerting/README.md
+++ b/tutorials/17-monitoring-alerting/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/18-data-sharing/README.md
+++ b/tutorials/18-data-sharing/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🔗 Tutorial 18: Data Sharing & OneLake Shortcuts

--- a/tutorials/19-copilot-ai/README.md
+++ b/tutorials/19-copilot-ai/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/22-networking-connectivity/README.md
+++ b/tutorials/22-networking-connectivity/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Overview

--- a/tutorials/23-shir-data-gateways/README.md
+++ b/tutorials/23-shir-data-gateways/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🎯 Overview

--- a/tutorials/24-snowflake-to-fabric/README.md
+++ b/tutorials/24-snowflake-to-fabric/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## ❄️ Tutorial 24: Snowflake to Microsoft Fabric Migration

--- a/tutorials/25-ibm-db2-source/README.md
+++ b/tutorials/25-ibm-db2-source/README.md
@@ -51,7 +51,7 @@
 | :arrow_left: **Previous** | [24-Snowflake to Fabric](../24-snowflake-to-fabric/README.md) |
 | ➡️ **Next** | [26-Multi-Source Streaming](../26-multi-source-streaming/README.md) |
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/26-multi-source-streaming/README.md
+++ b/tutorials/26-multi-source-streaming/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 📡 Tutorial 26: Multi-Source Real-Time Intelligence

--- a/tutorials/27-video-security-analytics/README.md
+++ b/tutorials/27-video-security-analytics/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/28-people-movement-analytics/README.md
+++ b/tutorials/28-people-movement-analytics/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/29-geolocation-analytics/README.md
+++ b/tutorials/29-geolocation-analytics/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/30-tribal-healthcare/README.md
+++ b/tutorials/30-tribal-healthcare/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/31-federal-dot-faa/README.md
+++ b/tutorials/31-federal-dot-faa/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/32-usda-agriculture/README.md
+++ b/tutorials/32-usda-agriculture/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/33-sba-small-business/README.md
+++ b/tutorials/33-sba-small-business/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/34-noaa-weather-climate/README.md
+++ b/tutorials/34-noaa-weather-climate/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/35-epa-environment/README.md
+++ b/tutorials/35-epa-environment/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/36-doi-interior/README.md
+++ b/tutorials/36-doi-interior/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/38-doj-justice/README.md
+++ b/tutorials/38-doj-justice/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/40-rag-production/README.md
+++ b/tutorials/40-rag-production/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/41-synapse-to-fabric/README.md
+++ b/tutorials/41-synapse-to-fabric/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/42-databricks-to-fabric/02_workflow_migration.md
+++ b/tutorials/42-databricks-to-fabric/02_workflow_migration.md
@@ -15,7 +15,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 📖 Overview

--- a/tutorials/42-databricks-to-fabric/README.md
+++ b/tutorials/42-databricks-to-fabric/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🧱 Tutorial 42: Databricks → Microsoft Fabric Migration

--- a/tutorials/43-redshift-to-fabric/README.md
+++ b/tutorials/43-redshift-to-fabric/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🟧 Tutorial 43: Amazon Redshift → Microsoft Fabric Migration

--- a/tutorials/44-bigquery-to-fabric/README.md
+++ b/tutorials/44-bigquery-to-fabric/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🔵 Tutorial 44: Google BigQuery → Microsoft Fabric Migration

--- a/tutorials/45-onprem-ssas-ssis-ssrs/README.md
+++ b/tutorials/45-onprem-ssas-ssis-ssrs/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/53-pharma/README.md
+++ b/tutorials/53-pharma/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/55-palantir-to-fabric/README.md
+++ b/tutorials/55-palantir-to-fabric/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/56-informatica-to-fabric/README.md
+++ b/tutorials/56-informatica-to-fabric/README.md
@@ -23,7 +23,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/57-databricks-better-together/README.md
+++ b/tutorials/57-databricks-better-together/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ## 🤝 Tutorial 57: Databricks Better Together — Mirroring, Security, and the Defense-in-Depth Story

--- a/tutorials/57-databricks-better-together/TEST_PLAN.md
+++ b/tutorials/57-databricks-better-together/TEST_PLAN.md
@@ -7,7 +7,7 @@
 Each step has **explicit expected output** so you can stop early if
 something diverges.
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services. That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-!!! note "Third-party references — publicly sourced, good-faith comparison"
+!!! info "Third-party references — publicly sourced, good-faith comparison"
     This page references non-Microsoft products and services (for example, the Teradata, SAS, Snowflake, and IBM DB2 migration/connectivity tutorials). That information is drawn from each vendor's **publicly available documentation** and is offered for honest, good-faith comparison only. This is a personal project written from a Microsoft Fabric and Azure perspective; it does **not** claim expertise in, or authority over, any third-party product, and nothing here is an official statement by, or endorsed by, those vendors. Capabilities, pricing, and features change often — always verify against the vendor's current official documentation. Where a third-party offering is the stronger choice, we say so plainly.
 
 ---


### PR DESCRIPTION
Follow-up to the positioning audit, mirroring the CSA-in-a-Box pass.

### Disclaimer restyle (your "make it a box that stands out")
- Switched the third-party disclaimer from the subtle gray `!!! note` to the prominent **`!!! info`** box (blue, icon) across all ~120 docs that carry it.
- Converted plain `>` blockquote notes into boxed admonitions so they're hard to miss: FAQ migrations note → `!!! info`; Teradata third-party-tools note → `!!! info`; supply-chain legal disclaimer → `!!! warning`; README third-party note → GitHub `[!NOTE]` callout (GitHub-rendered).

### Closed an audit gap
My original scan pattern **omitted `Oracle`** (and a couple others), so these never got the disclaimer — now fixed (`!!! info` added, vendor names kept as factual sources):
`02_DATA_GATEWAY`, `03_PIPELINES_DATA_MOVEMENT`, `04_METADATA_DRIVEN_PIPELINES`, `09_SOURCE_SPECIFIC_PATTERNS`, `11_ORACLE_GATEWAY_TROUBLESHOOTING`, `performance-parallelism`, `best-practices/index`, `features/direct-lake`, `operations/observability-stack` (Splunk), `features/eventhouse-vector-database` (Pinecone/Weaviate — also softened a superiority line).

### Nav/title de-naming (your "Azure vs MuleSoft" analog)
- Nav label **"Fabric vs Databricks vs Synapse" → "Fabric vs Competitor vs Synapse"** (the page H1 was already de-named, so nav now matches the body).

### Verified remaining matches are false positives
"Verti**cal**", "SAS Protocol"/Shared Access Signature, the `# Databricks notebook source` magic header, **Azure** AI Foundry, "Snowflake schema" (modeling term), a `DB2[(…)]` mermaid node id — all left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)